### PR TITLE
Update OpenOrClosed.Core.csproj

### DIFF
--- a/OpenOrClosed.Core/OpenOrClosed.Core.csproj
+++ b/OpenOrClosed.Core/OpenOrClosed.Core.csproj
@@ -31,7 +31,7 @@
 	<PackageProjectUrl>https://github.com/YourITGroup/OpenOrClosed</PackageProjectUrl>
 	<RepositoryUrl>https://github.com/YourITGroup/OpenOrClosed</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>
-	<PackageTags>Umbraco Business Hours Umbraco Datatype umbraco-marketplace</PackageTags>
+	<PackageTags>Umbraco Business Hours Umbraco Datatype</PackageTags>
 	<PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
 	<PackageReleaseNotes>Targeting Umbraco 10+</PackageReleaseNotes>
 	<PackageReadmeFile>README.nuget.md</PackageReadmeFile>


### PR DESCRIPTION
This update removes the `umbraco-marketplace` tag from the core project, as likely it's not beneficial to list that independently on the Umbraco marketplace.  With this update only the component that you would expect users to install will be listed.