### PR TITLE
Feature: Hide comment field

### DIFF
--- a/OpenOrClosed.Core/PropertyEditors/AbstractHoursConfiguration.cs
+++ b/OpenOrClosed.Core/PropertyEditors/AbstractHoursConfiguration.cs
@@ -19,6 +19,11 @@ public abstract class AbstractHoursConfiguration
         Description = "Make Closed Hours Optional")]
     public bool ClosedHoursOptional { get; set; }
 
+    [ConfigurationField("hideCommentField", "Hide comment field",
+        "boolean",
+        Description = "If checked, the comment field will be hidden.")]
+    public bool HideCommentField { get; set; }
+
     [ConfigurationField("time_24hr", "Time Format",
         "~/App_Plugins/OpenOrClosed/views/prevalues/timeformat.html",
         Description = "12/24 hour clock")]

--- a/OpenOrClosed/App_Plugins/OpenOrClosed/js/SpecialHours.controller.js
+++ b/OpenOrClosed/App_Plugins/OpenOrClosed/js/SpecialHours.controller.js
@@ -15,6 +15,7 @@
         labelClosed: 'Closed',
         hoursOptional: false,
         closedHoursOptional: false,
+        hideCommentField: false,
         icons: {
             time: "icon-time",
             date: "icon-calendar",
@@ -360,7 +361,7 @@
             let vm = getDateVm(index)
 
             if (!Array.isArray(date.hoursOfBusiness)) {
-                date.hoursOfBusiness = []
+                vm.hoursOfBusiness = []
             }
 
             if (!Array.isArray(vm.hours)) {

--- a/OpenOrClosed/App_Plugins/OpenOrClosed/js/SpecialHours.controller.js
+++ b/OpenOrClosed/App_Plugins/OpenOrClosed/js/SpecialHours.controller.js
@@ -361,7 +361,7 @@
             let vm = getDateVm(index)
 
             if (!Array.isArray(date.hoursOfBusiness)) {
-                vm.hoursOfBusiness = []
+                date.hoursOfBusiness = []
             }
 
             if (!Array.isArray(vm.hours)) {

--- a/OpenOrClosed/App_Plugins/OpenOrClosed/js/StandardHours.controller.js
+++ b/OpenOrClosed/App_Plugins/OpenOrClosed/js/StandardHours.controller.js
@@ -13,6 +13,7 @@
         labelClosed: 'Closed',
         hoursOptional: false,
         closedHoursOptional: false,
+        hideCommentField: false,
         labelBankHolidays: 'Bank Holidays',
         icons: {
             time: "icon-time",

--- a/OpenOrClosed/App_Plugins/OpenOrClosed/views/specialHours.html
+++ b/OpenOrClosed/App_Plugins/OpenOrClosed/views/specialHours.html
@@ -43,11 +43,8 @@
                     <label ng-show="!d.isOpen" ng-class="model.config.classClosed">{{model.config.labelClosed}}</label>
                 </div>
 
-                <textarea ng-show="!d.isOpen" ng-model="d.closedComment"
+                <textarea ng-show="!model.config.hideCommentField && !d.isOpen" ng-model="d.closedComment"
                           placeholder="{{vm.labels.placeholderClosedReason}}" class="ui-textarea"></textarea>
-
-                <textarea ng-show="d.isOpen && d.hoursOfBusiness.length === 0" ng-model="d.openComment"
-                          placeholder="{{vm.labels.placeholderOpenReason}}" class="ui-textarea"></textarea>
 
                 <div class="span5" ng-if="!model.config.excludeTimes" ng-show="d.isOpen">
                     <div ng-repeat="h in d.hoursOfBusiness" class="row">
@@ -115,8 +112,12 @@
                             </umb-toggle>
                         </div>
 
-                        <textarea ng-model="h.comment" placeholder="{{vm.labels.placeholderOpenReason}}" class="ui-textarea"></textarea>
+                        <textarea ng-show="!model.config.hideCommentField" ng-model="h.comment" placeholder="{{vm.labels.placeholderOpenReason}}" class="ui-textarea"></textarea>
                     </div>
+
+                    <textarea ng-show="!model.config.hideCommentField && d.isOpen && d.hoursOfBusiness.length === 0" ng-model="d.openComment"
+                              placeholder="{{vm.labels.placeholderOpenReason}}" class="ui-textarea"></textarea>
+
                     <button type="button" class="umb-node-preview-add mb3 add-hours-btn" ng-click="addHours($index)">
                         <localize key="content_addHours">Add hours</localize>
                     </button>

--- a/OpenOrClosed/App_Plugins/OpenOrClosed/views/standardHours.html
+++ b/OpenOrClosed/App_Plugins/OpenOrClosed/views/standardHours.html
@@ -14,11 +14,8 @@
                     <label ng-show="!d.isOpen" ng-class="model.config.classClosed">{{model.config.labelClosed}}</label>
                 </div>
 
-                <textarea ng-show="!d.isOpen" ng-model="d.closedComment"
+                <textarea ng-show="!model.config.hideCommentField && !d.isOpen" ng-model="d.closedComment"
                           placeholder="{{vm.labels.placeholderClosedReason}}" class="ui-textarea"></textarea>
-
-                <textarea ng-show="d.isOpen && d.hoursOfBusiness.length === 0" ng-model="d.openComment"
-                          placeholder="{{vm.labels.placeholderOpenReason}}" class="ui-textarea"></textarea>
 
                 <div class="span5" ng-if="!model.config.excludeTimes" ng-show="d.isOpen">
                     <div ng-repeat="h in d.hoursOfBusiness" class="row">
@@ -75,7 +72,7 @@
 
                         </div>
 
-                        <textarea ng-model="h.comment" placeholder="{{vm.labels.placeholderOpenReason}}" class="ui-textarea"></textarea>
+                        <textarea ng-show="!model.config.hideCommentField" ng-model="h.comment" placeholder="{{vm.labels.placeholderOpenReason}}" class="ui-textarea"></textarea>
 
                         <span ng-show="model.config.showAppointmentOnly">
                             <umb-toggle checked="h.byAppointmentOnly"
@@ -87,6 +84,10 @@
                             </umb-toggle>
                         </span>
                     </div>
+
+                    <textarea ng-show="!model.config.hideCommentField && d.isOpen && d.hoursOfBusiness.length === 0" ng-model="d.openComment"
+                              placeholder="{{vm.labels.placeholderOpenReason}}" class="ui-textarea"></textarea>
+
                     <button type="button" class="umb-node-preview-add mb3 add-hours-btn" ng-click="addHours($index)">
                         <localize key="content_addHours">Add hours</localize>
                     </button>


### PR DESCRIPTION
If the comment field is not necessary, the property editor can appear cluttered.
This PR adds a configuration field that lets the developer hide the comment field.

If you decide to merge this PR you can reject PR #56, since this PR also will fix #55 