### PR TITLE
Clipboard copy/paste for all four property editors

### DIFF
--- a/OpenOrClosed/Client/src/bundle.manifests.ts
+++ b/OpenOrClosed/Client/src/bundle.manifests.ts
@@ -1,3 +1,4 @@
+import { manifests as clipboard } from './clipboard/manifest'
 import { manifests as holidays } from './holidays/manifest'
 import { manifests as localization } from './localization/manifest'
 import { manifests as specialHours } from './special-hours/manifest'
@@ -16,5 +17,7 @@ export const manifests: Array<UmbExtensionManifest> = [
   ...weeklyHours,
   ...holidays,
   ...rangeModal,
-  ...timeInput
+  ...timeInput,
+  // Last, so every property editor UI it references is already registered.
+  ...clipboard
 ];

--- a/OpenOrClosed/Client/src/clipboard/constants.ts
+++ b/OpenOrClosed/Client/src/clipboard/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * One clipboard entry value type per editor. The type string is the whole compatibility contract:
+ * because Standard and Weekly hours do not share one, a weekly value can never reach a date-keyed
+ * editor and no translator has to check for it.
+ */
+export const OOC_STANDARD_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE = 'openOrClosed.standardHours';
+export const OOC_SPECIAL_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE = 'openOrClosed.specialHours';
+export const OOC_WEEKLY_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE = 'openOrClosed.weeklyHours';
+export const OOC_HOLIDAYS_CLIPBOARD_ENTRY_VALUE_TYPE = 'openOrClosed.holidays';

--- a/OpenOrClosed/Client/src/clipboard/entry-value.test.ts
+++ b/OpenOrClosed/Client/src/clipboard/entry-value.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+    OOC_CLIPBOARD_ENTRY_VERSION,
+    unwrapEntryValue,
+    wrapEntryValue,
+} from './entry-value.js';
+
+describe('wrapEntryValue', () => {
+    it('stamps the current entry version', () => {
+        expect(wrapEntryValue([{ isOpen: true }])).toEqual({
+            version: OOC_CLIPBOARD_ENTRY_VERSION,
+            value: [{ isOpen: true }],
+        });
+    });
+
+    it('clones deeply, so later edits to live editor state do not reach the entry', () => {
+        const value = [{ hoursOfBusiness: [{ opensAt: '09:00:00' }] }];
+        const entry = wrapEntryValue(value);
+
+        value[0].hoursOfBusiness[0].opensAt = '11:00:00';
+
+        expect(entry.value[0].hoursOfBusiness[0].opensAt).toBe('09:00:00');
+    });
+});
+
+describe('unwrapEntryValue', () => {
+    it('returns the inner value', () => {
+        expect(unwrapEntryValue(wrapEntryValue(['monday']))).toEqual(['monday']);
+    });
+
+    it('clones deeply, so editing a pasted value does not reach the entry', () => {
+        const entry = wrapEntryValue([{ isOpen: true }]);
+        const unwrapped = unwrapEntryValue<Array<{ isOpen: boolean }>>(entry);
+
+        unwrapped[0].isOpen = false;
+
+        expect(entry.value[0].isOpen).toBe(true);
+    });
+
+    it.each([
+        ['null', null],
+        ['undefined', undefined],
+        ['a string', 'openOrClosed.standardHours'],
+        ['a bare unwrapped array', [{ isOpen: true }]],
+        ['a missing version', { value: [] }],
+        ['an older version', { version: 0, value: [] }],
+        ['a newer version', { version: 2, value: [] }],
+        ['a missing value', { version: OOC_CLIPBOARD_ENTRY_VERSION }],
+        ['a null value', { version: OOC_CLIPBOARD_ENTRY_VERSION, value: null }],
+    ])('throws for %s', (_label, entryValue) => {
+        expect(() => unwrapEntryValue(entryValue)).toThrow();
+    });
+});

--- a/OpenOrClosed/Client/src/clipboard/entry-value.ts
+++ b/OpenOrClosed/Client/src/clipboard/entry-value.ts
@@ -1,0 +1,40 @@
+/**
+ * Clipboard entries sit in the browser's localStorage indefinitely, so each one records the shape
+ * version that wrote it. A build that does not recognise a version declines the entry instead of
+ * guessing: the paste action then surfaces the failure, rather than writing rubbish into a document.
+ */
+export const OOC_CLIPBOARD_ENTRY_VERSION = 1;
+
+export interface OocClipboardEntryValue<T> {
+    version: number;
+    value: T;
+}
+
+/** Stamps and deep-clones a live property value, ready to be serialised into the clipboard. */
+export function wrapEntryValue<T>(value: T): OocClipboardEntryValue<T> {
+    return { version: OOC_CLIPBOARD_ENTRY_VERSION, value: structuredClone(value) };
+}
+
+/**
+ * The inner value of an entry this build understands. Throws for anything else - including a bare
+ * value written by a build that predates the wrapper.
+ */
+export function unwrapEntryValue<T>(entryValue: unknown): T {
+    if (entryValue === null || typeof entryValue !== 'object' || Array.isArray(entryValue)) {
+        throw new Error('Clipboard entry value is not an OpenOrClosed entry.');
+    }
+
+    const { version, value } = entryValue as Partial<OocClipboardEntryValue<T>>;
+
+    if (version !== OOC_CLIPBOARD_ENTRY_VERSION) {
+        throw new Error(`Unsupported OpenOrClosed clipboard entry version: ${String(version)}.`);
+    }
+
+    // The copy action refuses a falsy property value, so a written entry always has one. Missing
+    // here means a corrupted entry, not an empty editor.
+    if (value === undefined || value === null) {
+        throw new Error('Clipboard entry value is empty.');
+    }
+
+    return structuredClone(value);
+}

--- a/OpenOrClosed/Client/src/clipboard/hours-copy.translator.test.ts
+++ b/OpenOrClosed/Client/src/clipboard/hours-copy.translator.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { OOC_CLIPBOARD_ENTRY_VERSION } from './entry-value.js';
+import { OocHoursClipboardCopyTranslator } from './hours-copy.translator.js';
+import { createTestHost } from './test-host.js';
+
+const translator = () => new OocHoursClipboardCopyTranslator(createTestHost());
+
+describe('OocHoursClipboardCopyTranslator', () => {
+    it('wraps an array property value', async () => {
+        await expect(translator().translate([{ isOpen: true }])).resolves.toEqual({
+            version: OOC_CLIPBOARD_ENTRY_VERSION,
+            value: [{ isOpen: true }],
+        });
+    });
+
+    it('wraps an object property value, as Holidays has', async () => {
+        await expect(translator().translate({ defaultHours: [], holidays: [] })).resolves.toEqual({
+            version: OOC_CLIPBOARD_ENTRY_VERSION,
+            value: { defaultHours: [], holidays: [] },
+        });
+    });
+
+    it('clones, so later edits in the editor do not reach the entry', async () => {
+        const value = [{ isOpen: true }];
+        const entry = await translator().translate(value);
+
+        value[0].isOpen = false;
+
+        expect((entry.value as Array<{ isOpen: boolean }>)[0].isOpen).toBe(true);
+    });
+
+    it.each([
+        ['null', null],
+        ['undefined', undefined],
+    ])('rejects %s rather than writing an unusable entry', async (_label, value) => {
+        await expect(translator().translate(value)).rejects.toThrow();
+    });
+});

--- a/OpenOrClosed/Client/src/clipboard/hours-copy.translator.ts
+++ b/OpenOrClosed/Client/src/clipboard/hours-copy.translator.ts
@@ -1,0 +1,23 @@
+import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
+import type { UmbClipboardCopyPropertyValueTranslator } from '@umbraco-cms/backoffice/clipboard';
+import { wrapEntryValue, type OocClipboardEntryValue } from './entry-value.js';
+
+/**
+ * Every OpenOrClosed editor copies the same way: stamp the value with the entry version and clone
+ * it. The entry value type is not this class's business - the manifest's `toClipboardEntryValueType`
+ * supplies it - so one translator is registered for all four editors.
+ */
+export class OocHoursClipboardCopyTranslator
+    extends UmbControllerBase
+    implements UmbClipboardCopyPropertyValueTranslator<unknown, OocClipboardEntryValue<unknown>>
+{
+    async translate(propertyValue: unknown): Promise<OocClipboardEntryValue<unknown>> {
+        if (propertyValue === undefined || propertyValue === null) {
+            throw new Error('Property value is missing.');
+        }
+
+        return wrapEntryValue(propertyValue);
+    }
+}
+
+export { OocHoursClipboardCopyTranslator as api };

--- a/OpenOrClosed/Client/src/clipboard/manifest-factory.ts
+++ b/OpenOrClosed/Client/src/clipboard/manifest-factory.ts
@@ -1,0 +1,74 @@
+import {
+    UMB_PROPERTY_HAS_VALUE_CONDITION_ALIAS,
+    UMB_WRITABLE_PROPERTY_CONDITION_ALIAS,
+} from '@umbraco-cms/backoffice/property';
+import type { ManifestClipboardPastePropertyValueTranslator } from '@umbraco-cms/backoffice/clipboard';
+
+export interface OocClipboardManifestArgs {
+    /** Human-readable editor name, for the manifest `name` fields only. */
+    editorName: string;
+    /** PascalCase segment that builds the manifest aliases, e.g. `StandardHours`. */
+    aliasSegment: string;
+    propertyEditorUiAlias: string;
+    entryValueType: string;
+    /**
+     * The editor's own paste translator loader. Typed as the manifest's `api` field rather than a
+     * bare `() => Promise<unknown>`, so a module that forgets its `api` export fails here rather
+     * than at runtime in the backoffice.
+     */
+    pasteTranslatorApi: ManifestClipboardPastePropertyValueTranslator['api'];
+}
+
+/**
+ * The five manifests that opt one property editor into Umbraco's property clipboard, matching what
+ * core's Block List registers. All four OpenOrClosed editors need exactly this set, differing only
+ * in their aliases and entry value type.
+ *
+ * The copy translator is shared by every editor; the paste translator is per editor, because each
+ * sanitises its own shape.
+ */
+export function oocClipboardManifests(args: OocClipboardManifestArgs): Array<UmbExtensionManifest> {
+    const forPropertyEditorUis = [args.propertyEditorUiAlias];
+
+    return [
+        {
+            type: 'propertyContext',
+            kind: 'clipboard',
+            alias: `OpenOrClosed.PropertyContext.${args.aliasSegment}.Clipboard`,
+            name: `${args.editorName} Clipboard Property Context`,
+            forPropertyEditorUis,
+        },
+        {
+            type: 'propertyAction',
+            kind: 'copyToClipboard',
+            alias: `OpenOrClosed.PropertyAction.${args.aliasSegment}.Clipboard.Copy`,
+            name: `${args.editorName} Copy To Clipboard Property Action`,
+            forPropertyEditorUis,
+            conditions: [{ alias: UMB_PROPERTY_HAS_VALUE_CONDITION_ALIAS }],
+        },
+        {
+            type: 'propertyAction',
+            kind: 'pasteFromClipboard',
+            alias: `OpenOrClosed.PropertyAction.${args.aliasSegment}.Clipboard.Paste`,
+            name: `${args.editorName} Paste From Clipboard Property Action`,
+            forPropertyEditorUis,
+            conditions: [{ alias: UMB_WRITABLE_PROPERTY_CONDITION_ALIAS }],
+        },
+        {
+            type: 'clipboardCopyPropertyValueTranslator',
+            alias: `OpenOrClosed.ClipboardCopyPropertyValueTranslator.${args.aliasSegment}`,
+            name: `${args.editorName} Clipboard Copy Property Value Translator`,
+            api: () => import('./hours-copy.translator.js'),
+            fromPropertyEditorUi: args.propertyEditorUiAlias,
+            toClipboardEntryValueType: args.entryValueType,
+        },
+        {
+            type: 'clipboardPastePropertyValueTranslator',
+            alias: `OpenOrClosed.ClipboardPastePropertyValueTranslator.${args.aliasSegment}`,
+            name: `${args.editorName} Clipboard Paste Property Value Translator`,
+            api: args.pasteTranslatorApi,
+            fromClipboardEntryValueType: args.entryValueType,
+            toPropertyEditorUi: args.propertyEditorUiAlias,
+        },
+    ];
+}

--- a/OpenOrClosed/Client/src/clipboard/manifest.ts
+++ b/OpenOrClosed/Client/src/clipboard/manifest.ts
@@ -1,5 +1,6 @@
 import { oocClipboardManifests } from './manifest-factory.js';
 import {
+    OOC_HOLIDAYS_CLIPBOARD_ENTRY_VALUE_TYPE,
     OOC_SPECIAL_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE,
     OOC_STANDARD_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE,
     OOC_WEEKLY_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE,
@@ -33,5 +34,12 @@ export const manifests: Array<UmbExtensionManifest> = [
         propertyEditorUiAlias: 'OpenOrClosed.PropertyEditorUi.WeeklyHours',
         entryValueType: OOC_WEEKLY_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE,
         pasteTranslatorApi: () => import('../weekly-hours/clipboard/paste.translator.js'),
+    }),
+    ...oocClipboardManifests({
+        editorName: 'Holidays',
+        aliasSegment: 'Holidays',
+        propertyEditorUiAlias: 'OpenOrClosed.PropertyEditorUi.Holidays',
+        entryValueType: OOC_HOLIDAYS_CLIPBOARD_ENTRY_VALUE_TYPE,
+        pasteTranslatorApi: () => import('../holidays/clipboard/paste.translator.js'),
     }),
 ];

--- a/OpenOrClosed/Client/src/clipboard/manifest.ts
+++ b/OpenOrClosed/Client/src/clipboard/manifest.ts
@@ -1,0 +1,37 @@
+import { oocClipboardManifests } from './manifest-factory.js';
+import {
+    OOC_SPECIAL_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE,
+    OOC_STANDARD_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE,
+    OOC_WEEKLY_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE,
+} from './constants.js';
+
+/**
+ * Clipboard registration for all four editors lives here rather than in each editor's own
+ * `manifest.ts`, because the factory imports Umbraco condition aliases at *runtime* and the
+ * property package it pulls in touches `document` while it loads. Node tests import the editor
+ * manifest modules directly - `localization/en.test.ts` does - so a runtime backoffice import
+ * there breaks them. Nothing imports this file except the bundle.
+ */
+export const manifests: Array<UmbExtensionManifest> = [
+    ...oocClipboardManifests({
+        editorName: 'Standard Business Hours',
+        aliasSegment: 'StandardHours',
+        propertyEditorUiAlias: 'OpenOrClosed.PropertyEditorUi.StandardHours',
+        entryValueType: OOC_STANDARD_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE,
+        pasteTranslatorApi: () => import('../standard-hours/clipboard/paste.translator.js'),
+    }),
+    ...oocClipboardManifests({
+        editorName: 'Special Business Hours',
+        aliasSegment: 'SpecialHours',
+        propertyEditorUiAlias: 'OpenOrClosed.PropertyEditorUi.SpecialHours',
+        entryValueType: OOC_SPECIAL_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE,
+        pasteTranslatorApi: () => import('../special-hours/clipboard/paste.translator.js'),
+    }),
+    ...oocClipboardManifests({
+        editorName: 'Weekly Hours',
+        aliasSegment: 'WeeklyHours',
+        propertyEditorUiAlias: 'OpenOrClosed.PropertyEditorUi.WeeklyHours',
+        entryValueType: OOC_WEEKLY_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE,
+        pasteTranslatorApi: () => import('../weekly-hours/clipboard/paste.translator.js'),
+    }),
+];

--- a/OpenOrClosed/Client/src/clipboard/test-host.ts
+++ b/OpenOrClosed/Client/src/clipboard/test-host.ts
@@ -1,0 +1,13 @@
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+
+/**
+ * The least a controller needs to be constructed outside the backoffice. The translators only ever
+ * touch their own argument - they consume no contexts - so none of this has to do real work.
+ */
+export function createTestHost(): UmbControllerHost {
+    return {
+        addUmbController() {},
+        removeUmbController() {},
+        getHostElement: () => undefined,
+    } as unknown as UmbControllerHost;
+}

--- a/OpenOrClosed/Client/src/holidays/clipboard/paste.translator.test.ts
+++ b/OpenOrClosed/Client/src/holidays/clipboard/paste.translator.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { createTestHost } from '../../clipboard/test-host.js';
+import { wrapEntryValue } from '../../clipboard/entry-value.js';
+import { OocHolidaysClipboardPasteTranslator } from './paste.translator.js';
+import type { Holiday } from '../holiday.js';
+
+const translator = () => new OocHolidaysClipboardPasteTranslator(createTestHost());
+
+const holiday = (name: string, start: string, end: string): Holiday => ({
+    name,
+    start,
+    end,
+    repeatYearly: false,
+    hoursMode: 'closed',
+    hours: [],
+});
+
+describe('OocHolidaysClipboardPasteTranslator', () => {
+    it('returns the schedule the entry carries', async () => {
+        const schedule = {
+            defaultHours: [],
+            holidays: [holiday('Christmas Day', '2026-12-25', '2026-12-25')],
+        };
+
+        await expect(translator().translate(wrapEntryValue(schedule))).resolves.toEqual(schedule);
+    });
+
+    it('keeps an expired holiday - removeExpiredHolidays is a converter setting, not an editor one', async () => {
+        const schedule = {
+            defaultHours: [],
+            holidays: [holiday('Old Bank Holiday', '2020-01-01', '2020-01-01')],
+        };
+
+        const pasted = await translator().translate(wrapEntryValue(schedule));
+
+        expect(pasted.holidays).toHaveLength(1);
+    });
+
+    it('fills in a schedule missing its keys', async () => {
+        await expect(translator().translate(wrapEntryValue({}))).resolves.toEqual({
+            defaultHours: [],
+            holidays: [],
+        });
+    });
+
+    it('drops a holiday with an impossible date', async () => {
+        const schedule = {
+            defaultHours: [],
+            holidays: [holiday('Not A Day', '2026-02-30', '2026-02-30')],
+        };
+
+        const pasted = await translator().translate(wrapEntryValue(schedule));
+
+        expect(pasted.holidays).toEqual([]);
+    });
+
+    it('clones, so editing the pasted schedule does not reach the entry', async () => {
+        const entry = wrapEntryValue({
+            defaultHours: [],
+            holidays: [holiday('Christmas Day', '2026-12-25', '2026-12-25')],
+        });
+
+        const pasted = await translator().translate(entry);
+        pasted.holidays[0].name = 'changed';
+
+        expect(entry.value.holidays[0].name).toBe('Christmas Day');
+    });
+
+    it('rejects an unrecognised version', async () => {
+        await expect(translator().translate({ version: 99, value: {} })).rejects.toThrow();
+    });
+});

--- a/OpenOrClosed/Client/src/holidays/clipboard/paste.translator.ts
+++ b/OpenOrClosed/Client/src/holidays/clipboard/paste.translator.ts
@@ -1,0 +1,23 @@
+import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
+import type { UmbClipboardPastePropertyValueTranslator } from '@umbraco-cms/backoffice/clipboard';
+import { unwrapEntryValue, type OocClipboardEntryValue } from '../../clipboard/entry-value.js';
+import { sanitizeSchedule, type HolidaySchedule } from '../holiday.js';
+
+/**
+ * The one object-valued editor. `sanitizeSchedule` already takes `unknown` and returns a well-formed
+ * schedule, which is exactly the contract wanted here - a clipboard entry may have been written by
+ * an older build of the package.
+ *
+ * Expired holidays are deliberately kept: `removeExpiredHolidays` governs the converted value and
+ * the Delivery API, not the editor, so that a mistyped date can still be corrected.
+ */
+export class OocHolidaysClipboardPasteTranslator
+    extends UmbControllerBase
+    implements UmbClipboardPastePropertyValueTranslator<OocClipboardEntryValue<unknown>, HolidaySchedule>
+{
+    async translate(entryValue: OocClipboardEntryValue<unknown>): Promise<HolidaySchedule> {
+        return sanitizeSchedule(unwrapEntryValue<unknown>(entryValue));
+    }
+}
+
+export { OocHolidaysClipboardPasteTranslator as api };

--- a/OpenOrClosed/Client/src/special-hours/clipboard/paste.translator.test.ts
+++ b/OpenOrClosed/Client/src/special-hours/clipboard/paste.translator.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { createTestHost } from '../../clipboard/test-host.js';
+import { wrapEntryValue } from '../../clipboard/entry-value.js';
+import { OocSpecialHoursClipboardPasteTranslator } from './paste.translator.js';
+import type { SpecialDay } from '../ooc-property-editor-ui-special-hours.element.js';
+
+const translator = () => new OocSpecialHoursClipboardPasteTranslator(createTestHost());
+
+const specialDay = (date: string | null): SpecialDay => ({
+    date,
+    isOpen: false,
+    openComment: '',
+    closedComment: 'Bank holiday',
+    hoursOfBusiness: [],
+});
+
+/** Today and a date safely either side of it, so the suite never straddles midnight. */
+const isoOffsetFromToday = (days: number): string => {
+    const date = new Date();
+    date.setDate(date.getDate() + days);
+    const pad = (value: number) => String(value).padStart(2, '0');
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+};
+
+const PAST = isoOffsetFromToday(-30);
+const TODAY = isoOffsetFromToday(0);
+const FUTURE = isoOffsetFromToday(30);
+
+const removeOldDates = (value: boolean) => [{ alias: 'removeOldDates', value }];
+
+describe('OocSpecialHoursClipboardPasteTranslator translate', () => {
+    it('returns the dates the entry carries, past ones included - the element filters them', async () => {
+        const days = [specialDay(PAST), specialDay(FUTURE)];
+
+        await expect(translator().translate(wrapEntryValue(days))).resolves.toEqual(days);
+    });
+
+    it('clones, so editing the pasted dates does not reach the entry', async () => {
+        const entry = wrapEntryValue([specialDay(FUTURE)]);
+
+        const pasted = await translator().translate(entry);
+        pasted[0].closedComment = 'changed';
+
+        expect(entry.value[0].closedComment).toBe('Bank holiday');
+    });
+
+    it('rejects an unrecognised version', async () => {
+        await expect(translator().translate({ version: 99, value: [] } as never)).rejects.toThrow();
+    });
+});
+
+describe('OocSpecialHoursClipboardPasteTranslator isCompatibleValue', () => {
+    it('accepts a future date when removeOldDates is on', async () => {
+        await expect(
+            translator().isCompatibleValue([specialDay(FUTURE)], removeOldDates(true)),
+        ).resolves.toBe(true);
+    });
+
+    it("accepts today's date when removeOldDates is on", async () => {
+        await expect(
+            translator().isCompatibleValue([specialDay(TODAY)], removeOldDates(true)),
+        ).resolves.toBe(true);
+    });
+
+    it('accepts a mixed entry when removeOldDates is on', async () => {
+        await expect(
+            translator().isCompatibleValue([specialDay(PAST), specialDay(FUTURE)], removeOldDates(true)),
+        ).resolves.toBe(true);
+    });
+
+    it('rejects an all-past entry when removeOldDates is on, because the paste would do nothing', async () => {
+        await expect(
+            translator().isCompatibleValue([specialDay(PAST)], removeOldDates(true)),
+        ).resolves.toBe(false);
+    });
+
+    it('rejects an empty entry when removeOldDates is on', async () => {
+        await expect(translator().isCompatibleValue([], removeOldDates(true))).resolves.toBe(false);
+    });
+
+    it('accepts an all-past entry when removeOldDates is off', async () => {
+        await expect(
+            translator().isCompatibleValue([specialDay(PAST)], removeOldDates(false)),
+        ).resolves.toBe(true);
+    });
+
+    it('treats the string "1" as on, as the config array delivers it', async () => {
+        await expect(
+            translator().isCompatibleValue([specialDay(PAST)], [{ alias: 'removeOldDates', value: '1' }]),
+        ).resolves.toBe(false);
+    });
+
+    it('defaults removeOldDates to on when the setting is absent, matching the editor default', async () => {
+        await expect(translator().isCompatibleValue([specialDay(PAST)], [])).resolves.toBe(false);
+    });
+
+    it('keeps a dated entry when the stored date carries a time', async () => {
+        await expect(
+            translator().isCompatibleValue([specialDay(`${FUTURE}T00:00:00`)], removeOldDates(true)),
+        ).resolves.toBe(true);
+    });
+
+    it('keeps an entry with a null date, which the element leaves alone', async () => {
+        await expect(
+            translator().isCompatibleValue([specialDay(null)], removeOldDates(true)),
+        ).resolves.toBe(true);
+    });
+});

--- a/OpenOrClosed/Client/src/special-hours/clipboard/paste.translator.ts
+++ b/OpenOrClosed/Client/src/special-hours/clipboard/paste.translator.ts
@@ -1,0 +1,62 @@
+import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
+import type { UmbClipboardPastePropertyValueTranslator } from '@umbraco-cms/backoffice/clipboard';
+import { unwrapEntryValue, type OocClipboardEntryValue } from '../../clipboard/entry-value.js';
+import type { SpecialDay } from '../ooc-property-editor-ui-special-hours.element.js';
+
+/** Umbraco hands a property editor its config as this array, values sometimes stringified. */
+export type OocPropertyEditorConfig = Array<{ alias: string; value: unknown }>;
+
+/** `YYYY-MM-DD` for today in the browser's own timezone. `new Date(iso)` would parse as UTC. */
+function todayKey(): string {
+    const now = new Date();
+    const pad = (value: number) => String(value).padStart(2, '0');
+    return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+}
+
+/** `YYYY-MM-DD` from a stored date, ignoring any time or timezone that came with it. */
+function dateKey(date: string): string {
+    return /^(\d{4})-(\d{2})-(\d{2})/.exec(date)?.[0] ?? '';
+}
+
+function readBoolean(config: OocPropertyEditorConfig, alias: string, fallback: boolean): boolean {
+    const entry = config.find((item) => item.alias === alias);
+    if (entry === undefined) return fallback;
+    if (typeof entry.value === 'string') return entry.value === '1' || entry.value === 'true';
+    return !!entry.value;
+}
+
+/**
+ * Special hours need no sanitising in `translate`: it gets no config, and the element's
+ * `_removeOldDates` already runs against the pasted value.
+ *
+ * `isCompatibleValue` earns its place though. With `removeOldDates` on, an entry whose dates are
+ * all in the past pastes successfully and is then filtered away to nothing, so the editor watches
+ * a paste do nothing at all. Better to hide the entry from the picker.
+ */
+export class OocSpecialHoursClipboardPasteTranslator
+    extends UmbControllerBase
+    implements
+        UmbClipboardPastePropertyValueTranslator<
+            OocClipboardEntryValue<SpecialDay[]>,
+            SpecialDay[],
+            OocPropertyEditorConfig
+        >
+{
+    async translate(entryValue: OocClipboardEntryValue<SpecialDay[]>): Promise<SpecialDay[]> {
+        return unwrapEntryValue<SpecialDay[]>(entryValue);
+    }
+
+    async isCompatibleValue(
+        propertyValue: SpecialDay[],
+        config: OocPropertyEditorConfig,
+    ): Promise<boolean> {
+        // `removeOldDates` defaults to true in the data type's defaultData, so an absent setting is on.
+        if (!readBoolean(config ?? [], 'removeOldDates', true)) return true;
+
+        const today = todayKey();
+
+        return (propertyValue ?? []).some((day) => !day.date || dateKey(day.date) >= today);
+    }
+}
+
+export { OocSpecialHoursClipboardPasteTranslator as api };

--- a/OpenOrClosed/Client/src/special-hours/manifest.ts
+++ b/OpenOrClosed/Client/src/special-hours/manifest.ts
@@ -1,3 +1,6 @@
+import { oocClipboardManifests } from '../clipboard/manifest-factory.js';
+import { OOC_SPECIAL_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE } from '../clipboard/constants.js';
+
 export const manifests: Array<UmbExtensionManifest> = [{
 	type: 'propertyEditorUi',
 	alias: 'OpenOrClosed.PropertyEditorUi.SpecialHours',
@@ -97,4 +100,11 @@ export const manifests: Array<UmbExtensionManifest> = [{
             ],
         },
 	},
-}];
+},
+...oocClipboardManifests({
+	editorName: 'Special Business Hours',
+	aliasSegment: 'SpecialHours',
+	propertyEditorUiAlias: 'OpenOrClosed.PropertyEditorUi.SpecialHours',
+	entryValueType: OOC_SPECIAL_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE,
+	pasteTranslatorApi: () => import('./clipboard/paste.translator.js'),
+})];

--- a/OpenOrClosed/Client/src/special-hours/manifest.ts
+++ b/OpenOrClosed/Client/src/special-hours/manifest.ts
@@ -1,6 +1,3 @@
-import { oocClipboardManifests } from '../clipboard/manifest-factory.js';
-import { OOC_SPECIAL_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE } from '../clipboard/constants.js';
-
 export const manifests: Array<UmbExtensionManifest> = [{
 	type: 'propertyEditorUi',
 	alias: 'OpenOrClosed.PropertyEditorUi.SpecialHours',
@@ -100,11 +97,4 @@ export const manifests: Array<UmbExtensionManifest> = [{
             ],
         },
 	},
-},
-...oocClipboardManifests({
-	editorName: 'Special Business Hours',
-	aliasSegment: 'SpecialHours',
-	propertyEditorUiAlias: 'OpenOrClosed.PropertyEditorUi.SpecialHours',
-	entryValueType: OOC_SPECIAL_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE,
-	pasteTranslatorApi: () => import('./clipboard/paste.translator.js'),
-})];
+}];

--- a/OpenOrClosed/Client/src/special-hours/ooc-property-editor-ui-special-hours.element.ts
+++ b/OpenOrClosed/Client/src/special-hours/ooc-property-editor-ui-special-hours.element.ts
@@ -3,7 +3,7 @@ import { BusinessHoursBaseElement, type BaseDayInterface, type BaseHoursConfig }
 import { umbBindToValidation } from '@umbraco-cms/backoffice/validation';
 import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/property-editor';
 
-interface SpecialDay extends BaseDayInterface {
+export interface SpecialDay extends BaseDayInterface {
     date: string | null;
 }
 

--- a/OpenOrClosed/Client/src/standard-hours/clipboard/paste.translator.test.ts
+++ b/OpenOrClosed/Client/src/standard-hours/clipboard/paste.translator.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { createTestHost } from '../../clipboard/test-host.js';
+import { wrapEntryValue } from '../../clipboard/entry-value.js';
+import { OocStandardHoursClipboardPasteTranslator } from './paste.translator.js';
+import type { StandardDay } from '../ooc-property-editor-ui-standard-hours.element.js';
+
+const translator = () => new OocStandardHoursClipboardPasteTranslator(createTestHost());
+
+const day = (dayoftheweek: string, day: number | null): StandardDay => ({
+    dayoftheweek,
+    day,
+    isOpen: true,
+    openComment: '',
+    closedComment: '',
+    hoursOfBusiness: [{ opensAt: '09:00:00', closesAt: '17:00:00', comment: '' }],
+});
+
+describe('OocStandardHoursClipboardPasteTranslator', () => {
+    it('returns the week the entry carries', async () => {
+        const week = [day('Monday', 1), day('Tuesday', 2)];
+
+        await expect(translator().translate(wrapEntryValue(week))).resolves.toEqual(week);
+    });
+
+    it('keeps an eight-row week intact - the element trims it from config, not the translator', async () => {
+        const week = [day('Monday', 1), day('Bank Holidays', null)];
+
+        const pasted = await translator().translate(wrapEntryValue(week));
+
+        expect(pasted).toHaveLength(2);
+        expect(pasted[1].dayoftheweek).toBe('Bank Holidays');
+    });
+
+    it('clones, so editing the pasted week does not reach the entry', async () => {
+        const entry = wrapEntryValue([day('Monday', 1)]);
+
+        const pasted = await translator().translate(entry);
+        pasted[0].isOpen = false;
+
+        expect(entry.value[0].isOpen).toBe(true);
+    });
+
+    it.each([
+        ['an unrecognised version', { version: 99, value: [] }],
+        ['a bare unwrapped week', [day('Monday', 1)]],
+    ])('rejects %s', async (_label, entryValue) => {
+        await expect(translator().translate(entryValue as never)).rejects.toThrow();
+    });
+});

--- a/OpenOrClosed/Client/src/standard-hours/clipboard/paste.translator.ts
+++ b/OpenOrClosed/Client/src/standard-hours/clipboard/paste.translator.ts
@@ -1,0 +1,21 @@
+import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
+import type { UmbClipboardPastePropertyValueTranslator } from '@umbraco-cms/backoffice/clipboard';
+import { unwrapEntryValue, type OocClipboardEntryValue } from '../../clipboard/entry-value.js';
+import type { StandardDay } from '../ooc-property-editor-ui-standard-hours.element.js';
+
+/**
+ * Standard hours need no sanitising here. `translate` gets no config - only `isCompatibleValue`
+ * does - and every config-dependent correction already lives in the element: `_initializeValue`
+ * rebuilds a default week from a value that is not an array, trims eight rows to seven or extends
+ * seven to eight from `showBankHolidays`, and re-labels the bank-holiday row.
+ */
+export class OocStandardHoursClipboardPasteTranslator
+    extends UmbControllerBase
+    implements UmbClipboardPastePropertyValueTranslator<OocClipboardEntryValue<StandardDay[]>, StandardDay[]>
+{
+    async translate(entryValue: OocClipboardEntryValue<StandardDay[]>): Promise<StandardDay[]> {
+        return unwrapEntryValue<StandardDay[]>(entryValue);
+    }
+}
+
+export { OocStandardHoursClipboardPasteTranslator as api };

--- a/OpenOrClosed/Client/src/standard-hours/manifest.ts
+++ b/OpenOrClosed/Client/src/standard-hours/manifest.ts
@@ -1,3 +1,6 @@
+import { oocClipboardManifests } from '../clipboard/manifest-factory.js';
+import { OOC_STANDARD_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE } from '../clipboard/constants.js';
+
 export const manifests: Array<UmbExtensionManifest> = [{
 	type: 'propertyEditorUi',
 	alias: 'OpenOrClosed.PropertyEditorUi.StandardHours',
@@ -97,4 +100,11 @@ export const manifests: Array<UmbExtensionManifest> = [{
             ],
         },
 	},
-}];
+},
+...oocClipboardManifests({
+	editorName: 'Standard Business Hours',
+	aliasSegment: 'StandardHours',
+	propertyEditorUiAlias: 'OpenOrClosed.PropertyEditorUi.StandardHours',
+	entryValueType: OOC_STANDARD_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE,
+	pasteTranslatorApi: () => import('./clipboard/paste.translator.js'),
+})];

--- a/OpenOrClosed/Client/src/standard-hours/manifest.ts
+++ b/OpenOrClosed/Client/src/standard-hours/manifest.ts
@@ -1,6 +1,3 @@
-import { oocClipboardManifests } from '../clipboard/manifest-factory.js';
-import { OOC_STANDARD_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE } from '../clipboard/constants.js';
-
 export const manifests: Array<UmbExtensionManifest> = [{
 	type: 'propertyEditorUi',
 	alias: 'OpenOrClosed.PropertyEditorUi.StandardHours',
@@ -100,11 +97,4 @@ export const manifests: Array<UmbExtensionManifest> = [{
             ],
         },
 	},
-},
-...oocClipboardManifests({
-	editorName: 'Standard Business Hours',
-	aliasSegment: 'StandardHours',
-	propertyEditorUiAlias: 'OpenOrClosed.PropertyEditorUi.StandardHours',
-	entryValueType: OOC_STANDARD_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE,
-	pasteTranslatorApi: () => import('./clipboard/paste.translator.js'),
-})];
+}];

--- a/OpenOrClosed/Client/src/standard-hours/ooc-property-editor-ui-standard-hours.element.ts
+++ b/OpenOrClosed/Client/src/standard-hours/ooc-property-editor-ui-standard-hours.element.ts
@@ -2,7 +2,7 @@ import { html, css, customElement } from '@umbraco-cms/backoffice/external/lit';
 import { BusinessHoursBaseElement, type BaseDayInterface, type BaseHoursConfig } from '../shared/business-hours-base.element.js';
 import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/property-editor';
 
-interface StandardDay extends BaseDayInterface {
+export interface StandardDay extends BaseDayInterface {
     dayoftheweek: string;
     day: number | null; // DayOfWeek enum value (0=Sunday, 1=Monday, etc.) or null for holidays
 }

--- a/OpenOrClosed/Client/src/weekly-hours/clipboard/paste.translator.test.ts
+++ b/OpenOrClosed/Client/src/weekly-hours/clipboard/paste.translator.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { createTestHost } from '../../clipboard/test-host.js';
+import { wrapEntryValue } from '../../clipboard/entry-value.js';
+import { OocWeeklyHoursClipboardPasteTranslator } from './paste.translator.js';
+import type { HoursRange } from '../../timeline/time-range.js';
+
+const translator = () => new OocWeeklyHoursClipboardPasteTranslator(createTestHost());
+
+const range = (start: string, end: string): HoursRange =>
+    ({ start, end, label: null, byAppointmentOnly: false });
+
+describe('OocWeeklyHoursClipboardPasteTranslator', () => {
+    it('returns the days the entry carries', async () => {
+        const week = [{ day: 1, ranges: [range('09:00', '17:00')] }];
+
+        await expect(translator().translate(wrapEntryValue(week))).resolves.toEqual(week);
+    });
+
+    it('keeps Sunday, which is day 0 and must not be treated as absent', async () => {
+        const week = [{ day: 0, ranges: [range('10:00', '14:00')] }];
+
+        await expect(translator().translate(wrapEntryValue(week))).resolves.toEqual(week);
+    });
+
+    it('drops a day whose ranges are all malformed', async () => {
+        const week = [
+            { day: 1, ranges: [{ start: 'nonsense', end: '17:00' }] },
+            { day: 2, ranges: [range('09:00', '17:00')] },
+        ];
+
+        await expect(translator().translate(wrapEntryValue(week))).resolves.toEqual([
+            { day: 2, ranges: [range('09:00', '17:00')] },
+        ]);
+    });
+
+    it.each([
+        ['a day above the week', 7],
+        ['a negative day', -1],
+        ['a fractional day', 1.5],
+        ['a stringified day', '1'],
+        ['a missing day', undefined],
+    ])('drops %s', async (_label, day) => {
+        const week = [{ day, ranges: [range('09:00', '17:00')] }];
+
+        await expect(translator().translate(wrapEntryValue(week))).resolves.toEqual([]);
+    });
+
+    it('returns an empty week for a value that is not an array', async () => {
+        await expect(translator().translate(wrapEntryValue({ day: 1 }))).resolves.toEqual([]);
+    });
+
+    it('rejects an unrecognised version', async () => {
+        await expect(translator().translate({ version: 99, value: [] })).rejects.toThrow();
+    });
+});

--- a/OpenOrClosed/Client/src/weekly-hours/clipboard/paste.translator.ts
+++ b/OpenOrClosed/Client/src/weekly-hours/clipboard/paste.translator.ts
@@ -1,0 +1,40 @@
+import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
+import type { UmbClipboardPastePropertyValueTranslator } from '@umbraco-cms/backoffice/clipboard';
+import { unwrapEntryValue, type OocClipboardEntryValue } from '../../clipboard/entry-value.js';
+import { sanitizeRanges } from '../../timeline/time-range.js';
+import type { WeeklyHoursDay } from '../ooc-weekly-hours.element.js';
+
+/**
+ * Unlike the fixed-week editors, weekly hours stores a sparse day list, so a malformed entry cannot
+ * be repaired on load - an out-of-range `day` would render a row belonging to no weekday. Sanitising
+ * here is therefore the translator's job. `sanitizeRanges` already takes `unknown` and coerces,
+ * which is the right contract at a trust boundary: an entry may have been written by an older build.
+ */
+export class OocWeeklyHoursClipboardPasteTranslator
+    extends UmbControllerBase
+    implements UmbClipboardPastePropertyValueTranslator<OocClipboardEntryValue<unknown>, WeeklyHoursDay[]>
+{
+    async translate(entryValue: OocClipboardEntryValue<unknown>): Promise<WeeklyHoursDay[]> {
+        const raw = unwrapEntryValue<unknown>(entryValue);
+        if (!Array.isArray(raw)) return [];
+
+        const week: WeeklyHoursDay[] = [];
+
+        for (const entry of raw) {
+            if (entry === null || typeof entry !== 'object') continue;
+
+            // System.DayOfWeek, so Sunday is 0 - `!day` would silently drop it.
+            const { day } = entry as { day?: unknown };
+            if (!Number.isInteger(day) || (day as number) < 0 || (day as number) > 6) continue;
+
+            const ranges = sanitizeRanges((entry as { ranges?: unknown }).ranges);
+            if (ranges.length === 0) continue;
+
+            week.push({ day: day as number, ranges });
+        }
+
+        return week;
+    }
+}
+
+export { OocWeeklyHoursClipboardPasteTranslator as api };

--- a/OpenOrClosed/Client/src/weekly-hours/ooc-weekly-hours.element.ts
+++ b/OpenOrClosed/Client/src/weekly-hours/ooc-weekly-hours.element.ts
@@ -16,7 +16,7 @@ import {
 import { OOC_RANGE_MODAL } from '../timeline/range-modal.token.js';
 import '../timeline/ooc-timeline.element.js';
 
-interface WeeklyHoursDay {
+export interface WeeklyHoursDay {
     day: number;
     ranges: HoursRange[];
 }

--- a/README.md
+++ b/README.md
@@ -42,6 +42,23 @@ Named date ranges that override the weekly schedule, with a shared **Default hol
 timeline at the top and a per-holiday override of `Default`, `Closed` or `Custom`. A holiday can
 repeat yearly, in which case it never expires.
 
+## Copying hours between nodes
+
+All four editors support Umbraco's property clipboard. Use the property's action menu to **Copy**
+its value, then **Replace** on the same property on another node — useful for rolling a set of bank
+holiday closures out across branch locations.
+
+Two things worth knowing before you rely on it:
+
+* **The clipboard is per browser.** Umbraco stores entries in the browser's local storage, so what
+  you copy is not visible to your colleagues or on your other devices.
+* **Pasting is one node at a time.** Umbraco has no bulk "apply this property to the nodes I have
+  selected" action, so a hundred branches means a hundred pastes. Copied entries are named
+  `<Node name> - <Property label>`, so the one you want stays easy to find in the picker.
+
+Copying between *different* editors is deliberately not possible — a Weekly Hours value cannot be
+pasted into Special Business Hours, even though both describe opening times.
+
 ## Choosing between them
 
 The package ships two pairs of hours editors. They do not interact, so pick one pair per site:
@@ -179,6 +196,10 @@ A few behaviours worth knowing:
   range is added or deleted, and block tooltips appear on keyboard focus as well as hover.
 * All four property editors now dispatch `UmbChangeEvent` rather than the deprecated
   `property-value-change`, which Umbraco removes in 20.0.0.
+* All four property editors now support Umbraco's property clipboard: **Copy** an editor's value
+  from one node and **Replace** it on another. Note that the clipboard is per browser, and that
+  pasting is one node at a time — Umbraco has no bulk apply. See
+  [Copying hours between nodes](#copying-hours-between-nodes).
 
 ### Version 17.1.2
 

--- a/docs/superpowers/plans/2026-08-26-clipboard-copy-paste-checklist.md
+++ b/docs/superpowers/plans/2026-08-26-clipboard-copy-paste-checklist.md
@@ -1,0 +1,63 @@
+# Clipboard copy/paste — manual checklist
+
+**Status: not yet run.**
+
+Written from `docs/superpowers/specs/2026-08-26-clipboard-copy-paste-design.md`, not from its
+implementation plan. A checklist derived from a plan cannot catch what the plan omitted.
+
+Unit tests cover the translators (52 of them). They cannot reach the part that matters most:
+whether a pasted value loads *clean*, or leaves the document dirty so the backoffice offers
+"Discard unsaved changes" on navigate-away.
+
+## Setup
+
+- A backoffice on Umbraco 17.1+ with the package installed and the client built (`npm run build`
+  in `OpenOrClosed/Client`).
+- At least **two** content nodes sharing a document type that carries all four properties, so a
+  value can be copied from one and pasted onto the other.
+- A second data type for each of Standard and Special Business Hours, configured differently from
+  the first (see items 5–8), to test config mismatches between source and target.
+- The property action menu is the `…` on the property, or right-click.
+
+## Checks
+
+- [ ] **1. Cross-node copy and paste.** For each of Standard Business Hours, Special Business
+  Hours, Weekly Hours and Holidays: set a value on node A, Copy, open node B, Replace. The value
+  arrives intact.
+- [ ] **2. Paste into an empty property.** No confirm dialog appears; the value lands.
+- [ ] **3. Paste over an existing value.** The confirm dialog appears and names the clipboard entry.
+  Cancelling leaves the existing value untouched.
+- [ ] **4. Conditions gate the actions.** Copy is absent on a property with no value
+  (`Umb.Condition.Property.HasValue`); Paste is absent on a read-only property
+  (`Umb.Condition.Property.Writable`). Check read-only via a user group without write permission,
+  or a property marked read-only on the document type.
+- [ ] **5. Standard Hours, bank holidays on → off.** Copy from a data type with **Show Bank
+  Holidays** on, paste into one with it off. 8 rows become 7. No orphan row, no eighth row hiding
+  in the saved value.
+- [ ] **6. Standard Hours, bank holidays off → on.** The reverse. 7 rows become 8, and the eighth
+  is labelled from the target's **Bank Holidays Label** setting — not from the source's.
+- [ ] **7. Special Hours, all-past entry is hidden.** On node A set only dates in the past, Copy.
+  On node B, with **Remove Old Dates** on, open the paste picker: **the entry is not listed at
+  all.** (Without this guard the paste succeeds and is then filtered to nothing, so the paste
+  appears to do nothing.)
+- [ ] **8. Special Hours, mixed entry.** An entry with both past and future dates pastes; past
+  dates are dropped, future dates survive. With **Remove Old Dates** off, the past dates are kept.
+- [ ] **9. Culture variants.** On a property varying by culture, copy on one culture and paste on
+  another. The paste lands on the culture being edited and does not disturb the other.
+- [ ] **10. Save, reload, publish.** After **every** paste above: save, navigate away and back,
+  and confirm the document is not dirty on arrival. Then publish and confirm the front-end value
+  converter output matches what a hand-entered equivalent produces. *A pasted value that loads
+  dirty, or that the converter reads differently from a hand-entered one, is the failure this whole
+  checklist exists to catch.*
+- [ ] **11. Entry naming.** Clipboard entries read `<Node name> - <Property label>` in the picker.
+- [ ] **12. Weekly Hours across time formats.** Copy from a node whose data type has **Time
+  Format** set to 24-hour, paste into one set to 12-hour. Times render in the target's format and
+  the stored values are unchanged.
+- [ ] **13. Cross-editor paste is impossible.** With a Weekly Hours value on the clipboard, open the
+  paste picker on Special Business Hours: the Weekly entry is not offered. Same in reverse. (Each
+  editor has its own clipboard entry value type, so no translator matches.)
+
+## Result
+
+Record the date run and the outcome here. If an item fails, stop and fix it rather than ticking and
+carrying on.

--- a/docs/superpowers/plans/2026-08-26-clipboard-copy-paste.md
+++ b/docs/superpowers/plans/2026-08-26-clipboard-copy-paste.md
@@ -1,0 +1,1208 @@
+# Clipboard copy/paste Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give all four OpenOrClosed property editors Umbraco's native clipboard copy and paste (replace), so opening hours can be copied from one content node and pasted onto another.
+
+**Architecture:** Umbraco 17.1's clipboard is opt-in per property editor: register a `propertyContext` of kind `clipboard`, two `propertyAction`s of kinds `copyToClipboard` and `pasteFromClipboard`, and a pair of value translators. All four editors register the identical set, so a factory emits it from `(uiAlias, entryValueType, pasteTranslatorAlias)`. Copy is one shared translator that stamps a version onto a deep clone; paste is one thin translator per editor that unwraps and sanitises. No C# changes and no new localisation keys.
+
+**Tech Stack:** TypeScript 5.8, Lit 3, vitest 3 (node environment), `@umbraco-cms/backoffice` 17.1 as a peer dependency.
+
+**Spec:** `docs/superpowers/specs/2026-08-26-clipboard-copy-paste-design.md`
+
+## Global Constraints
+
+- Work in `OpenOrClosed/Client/`. All paths below are relative to that directory unless stated otherwise.
+- **No C# changes.** Both editors are already `ValueTypes.Json` with a `propertyEditorSchemaAlias`, which is all the clipboard needs.
+- **No new localisation keys.** The `copyToClipboard` and `pasteFromClipboard` kinds carry their own icon and label ("Copy", "Replace") from core.
+- Run tests with `npx vitest run <path>` for one file, `npm test` for all. Test files are `src/**/*.test.ts`, colocated with the code, and run in vitest's **node** environment — no DOM.
+- Import sibling modules with the `.js` extension (`./entry-value.js`), matching every existing file.
+- `tsconfig.json` sets `strict`, `noUnusedLocals`, `noUnusedParameters` and `verbatimModuleSyntax`. Prefix deliberately unused parameters with `_`, and use `import type` for type-only imports.
+- Final gate before the last commit: `npm run build` (runs `tsc && vite build`).
+- Entry value type strings, verbatim:
+  - `openOrClosed.standardHours`
+  - `openOrClosed.specialHours`
+  - `openOrClosed.weeklyHours`
+  - `openOrClosed.holidays`
+- Entry shape version: `1`.
+- These import paths are all verified to resolve and typecheck: `@umbraco-cms/backoffice/class-api` (`UmbControllerBase`), `@umbraco-cms/backoffice/controller-api` (`UmbControllerHost`), `@umbraco-cms/backoffice/clipboard` (both translator interfaces, type-only), `@umbraco-cms/backoffice/property` (both condition aliases).
+- Manifest interfaces are declared into the global `UmbExtensionManifestMap` by the backoffice package. Keep the existing `Array<UmbExtensionManifest>` annotation and import nothing for it.
+- Property editor UI aliases, verbatim: `OpenOrClosed.PropertyEditorUi.StandardHours`, `OpenOrClosed.PropertyEditorUi.SpecialHours`, `OpenOrClosed.PropertyEditorUi.WeeklyHours`, `OpenOrClosed.PropertyEditorUi.Holidays`.
+
+---
+
+### Task 1: Versioned clipboard entry wrapper
+
+Clipboard entries live in the browser's `localStorage` indefinitely, so every entry carries the shape version that wrote it. A build that does not recognise a version must decline the entry rather than guess — a wrong guess writes rubbish into a document. Everything else in this plan depends on this module, so it goes first.
+
+**Files:**
+- Create: `src/clipboard/constants.ts`
+- Create: `src/clipboard/entry-value.ts`
+- Test: `src/clipboard/entry-value.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `OOC_STANDARD_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE`, `OOC_SPECIAL_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE`, `OOC_WEEKLY_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE`, `OOC_HOLIDAYS_CLIPBOARD_ENTRY_VALUE_TYPE` — `const` strings.
+  - `OOC_CLIPBOARD_ENTRY_VERSION: number`
+  - `interface OocClipboardEntryValue<T> { version: number; value: T }`
+  - `wrapEntryValue<T>(value: T): OocClipboardEntryValue<T>`
+  - `unwrapEntryValue<T>(entryValue: unknown): T`
+
+- [ ] **Step 1: Write the entry value type constants**
+
+`src/clipboard/constants.ts`:
+
+```ts
+/**
+ * One clipboard entry value type per editor. The type string is the whole compatibility contract:
+ * because Standard and Weekly hours do not share one, a weekly value can never reach a date-keyed
+ * editor and no translator has to check for it.
+ */
+export const OOC_STANDARD_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE = 'openOrClosed.standardHours';
+export const OOC_SPECIAL_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE = 'openOrClosed.specialHours';
+export const OOC_WEEKLY_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE = 'openOrClosed.weeklyHours';
+export const OOC_HOLIDAYS_CLIPBOARD_ENTRY_VALUE_TYPE = 'openOrClosed.holidays';
+```
+
+- [ ] **Step 2: Write the failing test**
+
+`src/clipboard/entry-value.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import {
+    OOC_CLIPBOARD_ENTRY_VERSION,
+    unwrapEntryValue,
+    wrapEntryValue,
+} from './entry-value.js';
+
+describe('wrapEntryValue', () => {
+    it('stamps the current entry version', () => {
+        expect(wrapEntryValue([{ isOpen: true }])).toEqual({
+            version: OOC_CLIPBOARD_ENTRY_VERSION,
+            value: [{ isOpen: true }],
+        });
+    });
+
+    it('clones deeply, so later edits to live editor state do not reach the entry', () => {
+        const value = [{ hoursOfBusiness: [{ opensAt: '09:00:00' }] }];
+        const entry = wrapEntryValue(value);
+
+        value[0].hoursOfBusiness[0].opensAt = '11:00:00';
+
+        expect(entry.value[0].hoursOfBusiness[0].opensAt).toBe('09:00:00');
+    });
+});
+
+describe('unwrapEntryValue', () => {
+    it('returns the inner value', () => {
+        expect(unwrapEntryValue(wrapEntryValue(['monday']))).toEqual(['monday']);
+    });
+
+    it('clones deeply, so editing a pasted value does not reach the entry', () => {
+        const entry = wrapEntryValue([{ isOpen: true }]);
+        const unwrapped = unwrapEntryValue<Array<{ isOpen: boolean }>>(entry);
+
+        unwrapped[0].isOpen = false;
+
+        expect(entry.value[0].isOpen).toBe(true);
+    });
+
+    it.each([
+        ['null', null],
+        ['undefined', undefined],
+        ['a string', 'openOrClosed.standardHours'],
+        ['a bare unwrapped array', [{ isOpen: true }]],
+        ['a missing version', { value: [] }],
+        ['an older version', { version: 0, value: [] }],
+        ['a newer version', { version: 2, value: [] }],
+        ['a missing value', { version: OOC_CLIPBOARD_ENTRY_VERSION }],
+        ['a null value', { version: OOC_CLIPBOARD_ENTRY_VERSION, value: null }],
+    ])('throws for %s', (_label, entryValue) => {
+        expect(() => unwrapEntryValue(entryValue)).toThrow();
+    });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npx vitest run src/clipboard/entry-value.test.ts`
+Expected: FAIL — `Failed to resolve import "./entry-value.js"`.
+
+- [ ] **Step 4: Write the implementation**
+
+`src/clipboard/entry-value.ts`:
+
+```ts
+/**
+ * Clipboard entries sit in the browser's localStorage indefinitely, so each one records the shape
+ * version that wrote it. A build that does not recognise a version declines the entry instead of
+ * guessing: the paste action then surfaces the failure, rather than writing rubbish into a document.
+ */
+export const OOC_CLIPBOARD_ENTRY_VERSION = 1;
+
+export interface OocClipboardEntryValue<T> {
+    version: number;
+    value: T;
+}
+
+/** Stamps and deep-clones a live property value, ready to be serialised into the clipboard. */
+export function wrapEntryValue<T>(value: T): OocClipboardEntryValue<T> {
+    return { version: OOC_CLIPBOARD_ENTRY_VERSION, value: structuredClone(value) };
+}
+
+/**
+ * The inner value of an entry this build understands. Throws for anything else - including a bare
+ * value written by a build that predates the wrapper.
+ */
+export function unwrapEntryValue<T>(entryValue: unknown): T {
+    if (entryValue === null || typeof entryValue !== 'object' || Array.isArray(entryValue)) {
+        throw new Error('Clipboard entry value is not an OpenOrClosed entry.');
+    }
+
+    const { version, value } = entryValue as Partial<OocClipboardEntryValue<T>>;
+
+    if (version !== OOC_CLIPBOARD_ENTRY_VERSION) {
+        throw new Error(`Unsupported OpenOrClosed clipboard entry version: ${String(version)}.`);
+    }
+
+    // The copy action refuses a falsy property value, so a written entry always has one. Missing
+    // here means a corrupted entry, not an empty editor.
+    if (value === undefined || value === null) {
+        throw new Error('Clipboard entry value is empty.');
+    }
+
+    return structuredClone(value);
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run src/clipboard/entry-value.test.ts`
+Expected: PASS — 13 tests (4 named, plus 9 from the `it.each`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/clipboard/constants.ts src/clipboard/entry-value.ts src/clipboard/entry-value.test.ts
+git commit -m "feat: versioned clipboard entry wrapper for the hours editors"
+```
+
+---
+
+### Task 2: Shared copy translator
+
+Every editor copies the same way, and the translator never needs to know its own entry value type — the manifest's `toClipboardEntryValueType` supplies it. So one class serves all four. A copy translator is **not** optional: `UmbClipboardCopyPropertyValueTranslatorValueResolver.resolve` throws `No clipboard copy translators found.` when no manifest matches the editor, so registering the actions without one gives an action that only errors.
+
+**Files:**
+- Create: `src/clipboard/test-host.ts`
+- Create: `src/clipboard/hours-copy.translator.ts`
+- Test: `src/clipboard/hours-copy.translator.test.ts`
+
+**Interfaces:**
+- Consumes: `wrapEntryValue`, `OocClipboardEntryValue` from Task 1.
+- Produces:
+  - `createTestHost(): UmbControllerHost` — the stub host every translator test uses to construct a controller outside the backoffice.
+  - `class OocHoursClipboardCopyTranslator` with `translate(propertyValue: unknown): Promise<OocClipboardEntryValue<unknown>>`, also exported as `api`.
+
+- [ ] **Step 1: Write the test host helper**
+
+`src/clipboard/test-host.ts`:
+
+```ts
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+
+/**
+ * The least a controller needs to be constructed outside the backoffice. The translators only ever
+ * touch their own argument - they consume no contexts - so none of this has to do real work.
+ */
+export function createTestHost(): UmbControllerHost {
+    return {
+        addUmbController() {},
+        removeUmbController() {},
+        getHostElement: () => undefined,
+    } as unknown as UmbControllerHost;
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+`src/clipboard/hours-copy.translator.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { OOC_CLIPBOARD_ENTRY_VERSION } from './entry-value.js';
+import { OocHoursClipboardCopyTranslator } from './hours-copy.translator.js';
+import { createTestHost } from './test-host.js';
+
+const translator = () => new OocHoursClipboardCopyTranslator(createTestHost());
+
+describe('OocHoursClipboardCopyTranslator', () => {
+    it('wraps an array property value', async () => {
+        await expect(translator().translate([{ isOpen: true }])).resolves.toEqual({
+            version: OOC_CLIPBOARD_ENTRY_VERSION,
+            value: [{ isOpen: true }],
+        });
+    });
+
+    it('wraps an object property value, as Holidays has', async () => {
+        await expect(translator().translate({ defaultHours: [], holidays: [] })).resolves.toEqual({
+            version: OOC_CLIPBOARD_ENTRY_VERSION,
+            value: { defaultHours: [], holidays: [] },
+        });
+    });
+
+    it('clones, so later edits in the editor do not reach the entry', async () => {
+        const value = [{ isOpen: true }];
+        const entry = await translator().translate(value);
+
+        value[0].isOpen = false;
+
+        expect((entry.value as Array<{ isOpen: boolean }>)[0].isOpen).toBe(true);
+    });
+
+    it.each([
+        ['null', null],
+        ['undefined', undefined],
+    ])('rejects %s rather than writing an unusable entry', async (_label, value) => {
+        await expect(translator().translate(value)).rejects.toThrow();
+    });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npx vitest run src/clipboard/hours-copy.translator.test.ts`
+Expected: FAIL — `Failed to resolve import "./hours-copy.translator.js"`.
+
+- [ ] **Step 4: Write the implementation**
+
+`src/clipboard/hours-copy.translator.ts`:
+
+```ts
+import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
+import type { UmbClipboardCopyPropertyValueTranslator } from '@umbraco-cms/backoffice/clipboard';
+import { wrapEntryValue, type OocClipboardEntryValue } from './entry-value.js';
+
+/**
+ * Every OpenOrClosed editor copies the same way: stamp the value with the entry version and clone
+ * it. The entry value type is not this class's business - the manifest's `toClipboardEntryValueType`
+ * supplies it - so one translator is registered for all four editors.
+ */
+export class OocHoursClipboardCopyTranslator
+    extends UmbControllerBase
+    implements UmbClipboardCopyPropertyValueTranslator<unknown, OocClipboardEntryValue<unknown>>
+{
+    async translate(propertyValue: unknown): Promise<OocClipboardEntryValue<unknown>> {
+        if (propertyValue === undefined || propertyValue === null) {
+            throw new Error('Property value is missing.');
+        }
+
+        return wrapEntryValue(propertyValue);
+    }
+}
+
+export { OocHoursClipboardCopyTranslator as api };
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run src/clipboard/hours-copy.translator.test.ts`
+Expected: PASS — 5 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/clipboard/test-host.ts src/clipboard/hours-copy.translator.ts src/clipboard/hours-copy.translator.test.ts
+git commit -m "feat: shared clipboard copy translator for the hours editors"
+```
+
+---
+
+### Task 3: Manifest factory and Standard Business Hours end to end
+
+The first editor through, so the factory gets proven against a real registration before it is repeated three times. Standard Hours needs no sanitising of its own: `_initializeValue` in `ooc-property-editor-ui-standard-hours.element.ts` already rebuilds a default week when the value is not an array, slices 8 rows to 7 or extends 7 to 8 from `showBankHolidays`, and re-labels the bank-holiday row from config. That is why `translate` is an unwrap and nothing more.
+
+**Files:**
+- Create: `src/clipboard/manifest-factory.ts`
+- Create: `src/standard-hours/clipboard/paste.translator.ts`
+- Test: `src/standard-hours/clipboard/paste.translator.test.ts`
+- Modify: `src/standard-hours/ooc-property-editor-ui-standard-hours.element.ts` — export the `StandardDay` interface (line 5, currently unexported)
+- Modify: `src/standard-hours/manifest.ts` — spread the factory output
+
+**Interfaces:**
+- Consumes: `OocClipboardEntryValue`, `unwrapEntryValue` (Task 1); `createTestHost` (Task 2); `OOC_STANDARD_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE` (Task 1).
+- Produces:
+  - `oocClipboardManifests(args: OocClipboardManifestArgs): Array<UmbExtensionManifest>` where
+    ```ts
+    interface OocClipboardManifestArgs {
+        editorName: string;        // e.g. 'Standard Business Hours' - used in manifest names only
+        aliasSegment: string;      // e.g. 'StandardHours' - used to build manifest aliases
+        propertyEditorUiAlias: string;
+        entryValueType: string;
+        pasteTranslatorApi: () => Promise<unknown>;
+    }
+    ```
+  - `export type StandardDay` from the standard hours element.
+  - `class OocStandardHoursClipboardPasteTranslator` with `translate(entryValue: OocClipboardEntryValue<StandardDay[]>): Promise<StandardDay[]>`, also exported as `api`.
+
+- [ ] **Step 1: Write the manifest factory**
+
+`src/clipboard/manifest-factory.ts`:
+
+```ts
+import {
+    UMB_PROPERTY_HAS_VALUE_CONDITION_ALIAS,
+    UMB_WRITABLE_PROPERTY_CONDITION_ALIAS,
+} from '@umbraco-cms/backoffice/property';
+
+export interface OocClipboardManifestArgs {
+    /** Human-readable editor name, for the manifest `name` fields only. */
+    editorName: string;
+    /** PascalCase segment that builds the manifest aliases, e.g. `StandardHours`. */
+    aliasSegment: string;
+    propertyEditorUiAlias: string;
+    entryValueType: string;
+    pasteTranslatorApi: () => Promise<unknown>;
+}
+
+/**
+ * The five manifests that opt one property editor into Umbraco's property clipboard, matching what
+ * core's Block List registers. All four OpenOrClosed editors need exactly this set, differing only
+ * in their aliases and entry value type.
+ *
+ * The copy translator is shared by every editor; the paste translator is per editor, because each
+ * sanitises its own shape.
+ */
+export function oocClipboardManifests(args: OocClipboardManifestArgs): Array<UmbExtensionManifest> {
+    const forPropertyEditorUis = [args.propertyEditorUiAlias];
+
+    return [
+        {
+            type: 'propertyContext',
+            kind: 'clipboard',
+            alias: `OpenOrClosed.PropertyContext.${args.aliasSegment}.Clipboard`,
+            name: `${args.editorName} Clipboard Property Context`,
+            forPropertyEditorUis,
+        },
+        {
+            type: 'propertyAction',
+            kind: 'copyToClipboard',
+            alias: `OpenOrClosed.PropertyAction.${args.aliasSegment}.Clipboard.Copy`,
+            name: `${args.editorName} Copy To Clipboard Property Action`,
+            forPropertyEditorUis,
+            conditions: [{ alias: UMB_PROPERTY_HAS_VALUE_CONDITION_ALIAS }],
+        },
+        {
+            type: 'propertyAction',
+            kind: 'pasteFromClipboard',
+            alias: `OpenOrClosed.PropertyAction.${args.aliasSegment}.Clipboard.Paste`,
+            name: `${args.editorName} Paste From Clipboard Property Action`,
+            forPropertyEditorUis,
+            conditions: [{ alias: UMB_WRITABLE_PROPERTY_CONDITION_ALIAS }],
+        },
+        {
+            type: 'clipboardCopyPropertyValueTranslator',
+            alias: `OpenOrClosed.ClipboardCopyPropertyValueTranslator.${args.aliasSegment}`,
+            name: `${args.editorName} Clipboard Copy Property Value Translator`,
+            api: () => import('./hours-copy.translator.js'),
+            fromPropertyEditorUi: args.propertyEditorUiAlias,
+            toClipboardEntryValueType: args.entryValueType,
+        },
+        {
+            type: 'clipboardPastePropertyValueTranslator',
+            alias: `OpenOrClosed.ClipboardPastePropertyValueTranslator.${args.aliasSegment}`,
+            name: `${args.editorName} Clipboard Paste Property Value Translator`,
+            api: args.pasteTranslatorApi,
+            fromClipboardEntryValueType: args.entryValueType,
+            toPropertyEditorUi: args.propertyEditorUiAlias,
+        },
+    ];
+}
+```
+
+- [ ] **Step 2: Export the `StandardDay` type**
+
+In `src/standard-hours/ooc-property-editor-ui-standard-hours.element.ts`, change line 5 from `interface StandardDay extends BaseDayInterface {` to `export interface StandardDay extends BaseDayInterface {`. Nothing else in the file changes — `import type` is erased under `verbatimModuleSyntax`, so importing this type pulls in no custom-element registration.
+
+- [ ] **Step 3: Write the failing test**
+
+`src/standard-hours/clipboard/paste.translator.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { createTestHost } from '../../clipboard/test-host.js';
+import { wrapEntryValue } from '../../clipboard/entry-value.js';
+import { OocStandardHoursClipboardPasteTranslator } from './paste.translator.js';
+import type { StandardDay } from '../ooc-property-editor-ui-standard-hours.element.js';
+
+const translator = () => new OocStandardHoursClipboardPasteTranslator(createTestHost());
+
+const day = (dayoftheweek: string, day: number | null): StandardDay => ({
+    dayoftheweek,
+    day,
+    isOpen: true,
+    openComment: '',
+    closedComment: '',
+    hoursOfBusiness: [{ opensAt: '09:00:00', closesAt: '17:00:00', comment: '' }],
+});
+
+describe('OocStandardHoursClipboardPasteTranslator', () => {
+    it('returns the week the entry carries', async () => {
+        const week = [day('Monday', 1), day('Tuesday', 2)];
+
+        await expect(translator().translate(wrapEntryValue(week))).resolves.toEqual(week);
+    });
+
+    it('keeps an eight-row week intact - the element trims it from config, not the translator', async () => {
+        const week = [day('Monday', 1), day('Bank Holidays', null)];
+
+        const pasted = await translator().translate(wrapEntryValue(week));
+
+        expect(pasted).toHaveLength(2);
+        expect(pasted[1].dayoftheweek).toBe('Bank Holidays');
+    });
+
+    it('clones, so editing the pasted week does not reach the entry', async () => {
+        const entry = wrapEntryValue([day('Monday', 1)]);
+
+        const pasted = await translator().translate(entry);
+        pasted[0].isOpen = false;
+
+        expect(entry.value[0].isOpen).toBe(true);
+    });
+
+    it.each([
+        ['an unrecognised version', { version: 99, value: [] }],
+        ['a bare unwrapped week', [day('Monday', 1)]],
+    ])('rejects %s', async (_label, entryValue) => {
+        await expect(translator().translate(entryValue as never)).rejects.toThrow();
+    });
+});
+```
+
+- [ ] **Step 4: Run test to verify it fails**
+
+Run: `npx vitest run src/standard-hours/clipboard/paste.translator.test.ts`
+Expected: FAIL — `Failed to resolve import "./paste.translator.js"`.
+
+- [ ] **Step 5: Write the implementation**
+
+`src/standard-hours/clipboard/paste.translator.ts`:
+
+```ts
+import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
+import type { UmbClipboardPastePropertyValueTranslator } from '@umbraco-cms/backoffice/clipboard';
+import { unwrapEntryValue, type OocClipboardEntryValue } from '../../clipboard/entry-value.js';
+import type { StandardDay } from '../ooc-property-editor-ui-standard-hours.element.js';
+
+/**
+ * Standard hours need no sanitising here. `translate` gets no config - only `isCompatibleValue`
+ * does - and every config-dependent correction already lives in the element: `_initializeValue`
+ * rebuilds a default week from a value that is not an array, trims eight rows to seven or extends
+ * seven to eight from `showBankHolidays`, and re-labels the bank-holiday row.
+ */
+export class OocStandardHoursClipboardPasteTranslator
+    extends UmbControllerBase
+    implements UmbClipboardPastePropertyValueTranslator<OocClipboardEntryValue<StandardDay[]>, StandardDay[]>
+{
+    async translate(entryValue: OocClipboardEntryValue<StandardDay[]>): Promise<StandardDay[]> {
+        return unwrapEntryValue<StandardDay[]>(entryValue);
+    }
+}
+
+export { OocStandardHoursClipboardPasteTranslator as api };
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `npx vitest run src/standard-hours/clipboard/paste.translator.test.ts`
+Expected: PASS — 5 tests.
+
+- [ ] **Step 7: Wire the manifests**
+
+In `src/standard-hours/manifest.ts`, add the imports at the top of the file and spread the factory output into the exported array. The file currently exports a single-element array; it becomes:
+
+```ts
+import { oocClipboardManifests } from '../clipboard/manifest-factory.js';
+import { OOC_STANDARD_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE } from '../clipboard/constants.js';
+
+export const manifests: Array<UmbExtensionManifest> = [
+	{
+		type: 'propertyEditorUi',
+		alias: 'OpenOrClosed.PropertyEditorUi.StandardHours',
+		// ... the existing manifest is untouched ...
+	},
+	...oocClipboardManifests({
+		editorName: 'Standard Business Hours',
+		aliasSegment: 'StandardHours',
+		propertyEditorUiAlias: 'OpenOrClosed.PropertyEditorUi.StandardHours',
+		entryValueType: OOC_STANDARD_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE,
+		pasteTranslatorApi: () => import('./clipboard/paste.translator.js'),
+	}),
+];
+```
+
+`bundle.manifests.ts` needs no change — it already spreads `standardHours`.
+
+- [ ] **Step 8: Typecheck and run the whole suite**
+
+Run: `npx tsc --noEmit && npm test`
+Expected: tsc silent; all tests pass, including the pre-existing ones.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/clipboard/manifest-factory.ts src/standard-hours/
+git commit -m "feat: clipboard copy/paste on the Standard Business Hours editor"
+```
+
+---
+
+### Task 4: Special Business Hours
+
+The only editor with an `isCompatibleValue`, and the reason it exists is concrete: with `removeOldDates` on, pasting an entry whose dates are all in the past succeeds and then `_removeOldDates` immediately filters everything out, so the editor watches a paste do nothing. The guard hides such an entry from the picker instead.
+
+Dates are compared as calendar dates against the browser's own today, not UTC — `new Date('2026-08-19')` parses as UTC midnight, which drops today's entry in negative UTC offsets. `_removeOldDates` in the element already carries a comment about exactly this. Reuse that approach rather than inventing another.
+
+`config` arrives as Umbraco's array form, `Array<{ alias: string; value: unknown }>` — the same shape `_mergeConfig` reads in `shared/business-hours-base.element.ts`, including the string `'1'`/`'0'` booleans it has to coerce.
+
+**Files:**
+- Create: `src/special-hours/clipboard/paste.translator.ts`
+- Test: `src/special-hours/clipboard/paste.translator.test.ts`
+- Modify: `src/special-hours/ooc-property-editor-ui-special-hours.element.ts` — export the `SpecialDay` interface (line 6)
+- Modify: `src/special-hours/manifest.ts`
+
+**Interfaces:**
+- Consumes: `unwrapEntryValue`, `OocClipboardEntryValue`, `OOC_SPECIAL_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE` (Task 1); `createTestHost` (Task 2); `oocClipboardManifests` (Task 3).
+- Produces:
+  - `export type SpecialDay` from the special hours element.
+  - `class OocSpecialHoursClipboardPasteTranslator` with `translate(entryValue: OocClipboardEntryValue<SpecialDay[]>): Promise<SpecialDay[]>` and `isCompatibleValue(propertyValue: SpecialDay[], config: OocPropertyEditorConfig): Promise<boolean>`, also exported as `api`.
+  - `type OocPropertyEditorConfig = Array<{ alias: string; value: unknown }>`, exported because it appears in `isCompatibleValue`'s public signature.
+
+- [ ] **Step 1: Export the `SpecialDay` type**
+
+In `src/special-hours/ooc-property-editor-ui-special-hours.element.ts`, change line 6 from `interface SpecialDay extends BaseDayInterface {` to `export interface SpecialDay extends BaseDayInterface {`.
+
+- [ ] **Step 2: Write the failing test**
+
+`src/special-hours/clipboard/paste.translator.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { createTestHost } from '../../clipboard/test-host.js';
+import { wrapEntryValue } from '../../clipboard/entry-value.js';
+import { OocSpecialHoursClipboardPasteTranslator } from './paste.translator.js';
+import type { SpecialDay } from '../ooc-property-editor-ui-special-hours.element.js';
+
+const translator = () => new OocSpecialHoursClipboardPasteTranslator(createTestHost());
+
+const specialDay = (date: string | null): SpecialDay => ({
+    date,
+    isOpen: false,
+    openComment: '',
+    closedComment: 'Bank holiday',
+    hoursOfBusiness: [],
+});
+
+/** Today and a date safely either side of it, so the suite never straddles midnight. */
+const isoOffsetFromToday = (days: number): string => {
+    const date = new Date();
+    date.setDate(date.getDate() + days);
+    const pad = (value: number) => String(value).padStart(2, '0');
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+};
+
+const PAST = isoOffsetFromToday(-30);
+const TODAY = isoOffsetFromToday(0);
+const FUTURE = isoOffsetFromToday(30);
+
+const removeOldDates = (value: boolean) => [{ alias: 'removeOldDates', value }];
+
+describe('OocSpecialHoursClipboardPasteTranslator translate', () => {
+    it('returns the dates the entry carries, past ones included - the element filters them', async () => {
+        const days = [specialDay(PAST), specialDay(FUTURE)];
+
+        await expect(translator().translate(wrapEntryValue(days))).resolves.toEqual(days);
+    });
+
+    it('clones, so editing the pasted dates does not reach the entry', async () => {
+        const entry = wrapEntryValue([specialDay(FUTURE)]);
+
+        const pasted = await translator().translate(entry);
+        pasted[0].closedComment = 'changed';
+
+        expect(entry.value[0].closedComment).toBe('Bank holiday');
+    });
+
+    it('rejects an unrecognised version', async () => {
+        await expect(translator().translate({ version: 99, value: [] } as never)).rejects.toThrow();
+    });
+});
+
+describe('OocSpecialHoursClipboardPasteTranslator isCompatibleValue', () => {
+    it('accepts a future date when removeOldDates is on', async () => {
+        await expect(
+            translator().isCompatibleValue([specialDay(FUTURE)], removeOldDates(true)),
+        ).resolves.toBe(true);
+    });
+
+    it("accepts today's date when removeOldDates is on", async () => {
+        await expect(
+            translator().isCompatibleValue([specialDay(TODAY)], removeOldDates(true)),
+        ).resolves.toBe(true);
+    });
+
+    it('accepts a mixed entry when removeOldDates is on', async () => {
+        await expect(
+            translator().isCompatibleValue([specialDay(PAST), specialDay(FUTURE)], removeOldDates(true)),
+        ).resolves.toBe(true);
+    });
+
+    it('rejects an all-past entry when removeOldDates is on, because the paste would do nothing', async () => {
+        await expect(
+            translator().isCompatibleValue([specialDay(PAST)], removeOldDates(true)),
+        ).resolves.toBe(false);
+    });
+
+    it('rejects an empty entry when removeOldDates is on', async () => {
+        await expect(translator().isCompatibleValue([], removeOldDates(true))).resolves.toBe(false);
+    });
+
+    it('accepts an all-past entry when removeOldDates is off', async () => {
+        await expect(
+            translator().isCompatibleValue([specialDay(PAST)], removeOldDates(false)),
+        ).resolves.toBe(true);
+    });
+
+    it('treats the string "1" as on, as the config array delivers it', async () => {
+        await expect(
+            translator().isCompatibleValue([specialDay(PAST)], [{ alias: 'removeOldDates', value: '1' }]),
+        ).resolves.toBe(false);
+    });
+
+    it('defaults removeOldDates to on when the setting is absent, matching the editor default', async () => {
+        await expect(translator().isCompatibleValue([specialDay(PAST)], [])).resolves.toBe(false);
+    });
+
+    it('keeps a dated entry when the stored date carries a time', async () => {
+        await expect(
+            translator().isCompatibleValue([specialDay(`${FUTURE}T00:00:00`)], removeOldDates(true)),
+        ).resolves.toBe(true);
+    });
+
+    it('keeps an entry with a null date, which the element leaves alone', async () => {
+        await expect(
+            translator().isCompatibleValue([specialDay(null)], removeOldDates(true)),
+        ).resolves.toBe(true);
+    });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npx vitest run src/special-hours/clipboard/paste.translator.test.ts`
+Expected: FAIL — `Failed to resolve import "./paste.translator.js"`.
+
+- [ ] **Step 4: Write the implementation**
+
+`src/special-hours/clipboard/paste.translator.ts`:
+
+```ts
+import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
+import type { UmbClipboardPastePropertyValueTranslator } from '@umbraco-cms/backoffice/clipboard';
+import { unwrapEntryValue, type OocClipboardEntryValue } from '../../clipboard/entry-value.js';
+import type { SpecialDay } from '../ooc-property-editor-ui-special-hours.element.js';
+
+/** Umbraco hands a property editor its config as this array, values sometimes stringified. */
+export type OocPropertyEditorConfig = Array<{ alias: string; value: unknown }>;
+
+/** `YYYY-MM-DD` for today in the browser's own timezone. `new Date(iso)` would parse as UTC. */
+function todayKey(): string {
+    const now = new Date();
+    const pad = (value: number) => String(value).padStart(2, '0');
+    return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+}
+
+/** `YYYY-MM-DD` from a stored date, ignoring any time or timezone that came with it. */
+function dateKey(date: string): string {
+    return /^(\d{4})-(\d{2})-(\d{2})/.exec(date)?.[0] ?? '';
+}
+
+function readBoolean(config: OocPropertyEditorConfig, alias: string, fallback: boolean): boolean {
+    const entry = config.find((item) => item.alias === alias);
+    if (entry === undefined) return fallback;
+    if (typeof entry.value === 'string') return entry.value === '1' || entry.value === 'true';
+    return !!entry.value;
+}
+
+/**
+ * Special hours need no sanitising in `translate`: it gets no config, and the element's
+ * `_removeOldDates` already runs against the pasted value.
+ *
+ * `isCompatibleValue` earns its place though. With `removeOldDates` on, an entry whose dates are
+ * all in the past pastes successfully and is then filtered away to nothing, so the editor watches
+ * a paste do nothing at all. Better to hide the entry from the picker.
+ */
+export class OocSpecialHoursClipboardPasteTranslator
+    extends UmbControllerBase
+    implements
+        UmbClipboardPastePropertyValueTranslator<
+            OocClipboardEntryValue<SpecialDay[]>,
+            SpecialDay[],
+            OocPropertyEditorConfig
+        >
+{
+    async translate(entryValue: OocClipboardEntryValue<SpecialDay[]>): Promise<SpecialDay[]> {
+        return unwrapEntryValue<SpecialDay[]>(entryValue);
+    }
+
+    async isCompatibleValue(
+        propertyValue: SpecialDay[],
+        config: OocPropertyEditorConfig,
+    ): Promise<boolean> {
+        // `removeOldDates` defaults to true in the data type's defaultData, so an absent setting is on.
+        if (!readBoolean(config ?? [], 'removeOldDates', true)) return true;
+
+        const today = todayKey();
+
+        return (propertyValue ?? []).some((day) => !day.date || dateKey(day.date) >= today);
+    }
+}
+
+export { OocSpecialHoursClipboardPasteTranslator as api };
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run src/special-hours/clipboard/paste.translator.test.ts`
+Expected: PASS — 13 tests.
+
+- [ ] **Step 6: Wire the manifests**
+
+In `src/special-hours/manifest.ts`, add the two imports and spread the factory output after the existing `propertyEditorUi` manifest:
+
+```ts
+import { oocClipboardManifests } from '../clipboard/manifest-factory.js';
+import { OOC_SPECIAL_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE } from '../clipboard/constants.js';
+
+// ... existing propertyEditorUi manifest ...
+	...oocClipboardManifests({
+		editorName: 'Special Business Hours',
+		aliasSegment: 'SpecialHours',
+		propertyEditorUiAlias: 'OpenOrClosed.PropertyEditorUi.SpecialHours',
+		entryValueType: OOC_SPECIAL_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE,
+		pasteTranslatorApi: () => import('./clipboard/paste.translator.js'),
+	}),
+```
+
+- [ ] **Step 7: Typecheck and run the whole suite**
+
+Run: `npx tsc --noEmit && npm test`
+Expected: tsc silent; all tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/special-hours/
+git commit -m "feat: clipboard copy/paste on the Special Business Hours editor"
+```
+
+---
+
+### Task 5: Weekly Hours
+
+Weekly Hours stores a sparse `{ day, ranges }` list rather than a fixed week, so a malformed entry cannot be repaired by the element the way a Standard Hours week can — an out-of-range `day` would render a row that maps to no weekday. This translator therefore does sanitise, reusing `sanitizeRanges` from `timeline/time-range.ts`, which already takes `unknown` and coerces.
+
+**Files:**
+- Create: `src/weekly-hours/clipboard/paste.translator.ts`
+- Test: `src/weekly-hours/clipboard/paste.translator.test.ts`
+- Modify: `src/weekly-hours/ooc-weekly-hours.element.ts` — export the `WeeklyHoursDay` interface (line 19)
+- Modify: `src/weekly-hours/manifest.ts`
+
+**Interfaces:**
+- Consumes: `unwrapEntryValue`, `OocClipboardEntryValue`, `OOC_WEEKLY_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE` (Task 1); `createTestHost` (Task 2); `oocClipboardManifests` (Task 3); `sanitizeRanges` from `src/timeline/time-range.ts`.
+- Produces:
+  - `export type WeeklyHoursDay` from the weekly hours element.
+  - `class OocWeeklyHoursClipboardPasteTranslator` with `translate(entryValue: OocClipboardEntryValue<unknown>): Promise<WeeklyHoursDay[]>`, also exported as `api`.
+
+- [ ] **Step 1: Export the `WeeklyHoursDay` type**
+
+In `src/weekly-hours/ooc-weekly-hours.element.ts`, change line 19 from `interface WeeklyHoursDay {` to `export interface WeeklyHoursDay {`.
+
+- [ ] **Step 2: Write the failing test**
+
+`src/weekly-hours/clipboard/paste.translator.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { createTestHost } from '../../clipboard/test-host.js';
+import { wrapEntryValue } from '../../clipboard/entry-value.js';
+import { OocWeeklyHoursClipboardPasteTranslator } from './paste.translator.js';
+import type { HoursRange } from '../../timeline/time-range.js';
+
+const translator = () => new OocWeeklyHoursClipboardPasteTranslator(createTestHost());
+
+const range = (start: string, end: string): HoursRange =>
+    ({ start, end, label: null, byAppointmentOnly: false });
+
+describe('OocWeeklyHoursClipboardPasteTranslator', () => {
+    it('returns the days the entry carries', async () => {
+        const week = [{ day: 1, ranges: [range('09:00', '17:00')] }];
+
+        await expect(translator().translate(wrapEntryValue(week))).resolves.toEqual(week);
+    });
+
+    it('keeps Sunday, which is day 0 and must not be treated as absent', async () => {
+        const week = [{ day: 0, ranges: [range('10:00', '14:00')] }];
+
+        await expect(translator().translate(wrapEntryValue(week))).resolves.toEqual(week);
+    });
+
+    it('drops a day whose ranges are all malformed', async () => {
+        const week = [
+            { day: 1, ranges: [{ start: 'nonsense', end: '17:00' }] },
+            { day: 2, ranges: [range('09:00', '17:00')] },
+        ];
+
+        await expect(translator().translate(wrapEntryValue(week))).resolves.toEqual([
+            { day: 2, ranges: [range('09:00', '17:00')] },
+        ]);
+    });
+
+    it.each([
+        ['a day above the week', 7],
+        ['a negative day', -1],
+        ['a fractional day', 1.5],
+        ['a stringified day', '1'],
+        ['a missing day', undefined],
+    ])('drops %s', async (_label, day) => {
+        const week = [{ day, ranges: [range('09:00', '17:00')] }];
+
+        await expect(translator().translate(wrapEntryValue(week))).resolves.toEqual([]);
+    });
+
+    it('returns an empty week for a value that is not an array', async () => {
+        await expect(translator().translate(wrapEntryValue({ day: 1 }))).resolves.toEqual([]);
+    });
+
+    it('rejects an unrecognised version', async () => {
+        await expect(translator().translate({ version: 99, value: [] })).rejects.toThrow();
+    });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npx vitest run src/weekly-hours/clipboard/paste.translator.test.ts`
+Expected: FAIL — `Failed to resolve import "./paste.translator.js"`.
+
+- [ ] **Step 4: Write the implementation**
+
+`src/weekly-hours/clipboard/paste.translator.ts`:
+
+```ts
+import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
+import type { UmbClipboardPastePropertyValueTranslator } from '@umbraco-cms/backoffice/clipboard';
+import { unwrapEntryValue, type OocClipboardEntryValue } from '../../clipboard/entry-value.js';
+import { sanitizeRanges } from '../../timeline/time-range.js';
+import type { WeeklyHoursDay } from '../ooc-weekly-hours.element.js';
+
+/**
+ * Unlike the fixed-week editors, weekly hours stores a sparse day list, so a malformed entry cannot
+ * be repaired on load - an out-of-range `day` would render a row belonging to no weekday. Sanitising
+ * here is therefore the translator's job. `sanitizeRanges` already takes `unknown` and coerces,
+ * which is the right contract at a trust boundary: an entry may have been written by an older build.
+ */
+export class OocWeeklyHoursClipboardPasteTranslator
+    extends UmbControllerBase
+    implements UmbClipboardPastePropertyValueTranslator<OocClipboardEntryValue<unknown>, WeeklyHoursDay[]>
+{
+    async translate(entryValue: OocClipboardEntryValue<unknown>): Promise<WeeklyHoursDay[]> {
+        const raw = unwrapEntryValue<unknown>(entryValue);
+        if (!Array.isArray(raw)) return [];
+
+        const week: WeeklyHoursDay[] = [];
+
+        for (const entry of raw) {
+            if (entry === null || typeof entry !== 'object') continue;
+
+            // System.DayOfWeek, so Sunday is 0 - `!day` would silently drop it.
+            const { day } = entry as { day?: unknown };
+            if (!Number.isInteger(day) || (day as number) < 0 || (day as number) > 6) continue;
+
+            const ranges = sanitizeRanges((entry as { ranges?: unknown }).ranges);
+            if (ranges.length === 0) continue;
+
+            week.push({ day: day as number, ranges });
+        }
+
+        return week;
+    }
+}
+
+export { OocWeeklyHoursClipboardPasteTranslator as api };
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run src/weekly-hours/clipboard/paste.translator.test.ts`
+Expected: PASS — 10 tests.
+
+- [ ] **Step 6: Wire the manifests**
+
+In `src/weekly-hours/manifest.ts`, add the two imports and spread the factory output after the existing `propertyEditorUi` manifest:
+
+```ts
+import { oocClipboardManifests } from '../clipboard/manifest-factory.js';
+import { OOC_WEEKLY_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE } from '../clipboard/constants.js';
+
+// ... existing propertyEditorUi manifest ...
+        ...oocClipboardManifests({
+            editorName: 'Weekly Hours',
+            aliasSegment: 'WeeklyHours',
+            propertyEditorUiAlias: 'OpenOrClosed.PropertyEditorUi.WeeklyHours',
+            entryValueType: OOC_WEEKLY_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE,
+            pasteTranslatorApi: () => import('./clipboard/paste.translator.js'),
+        }),
+```
+
+- [ ] **Step 7: Typecheck and run the whole suite**
+
+Run: `npx tsc --noEmit && npm test`
+Expected: tsc silent; all tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/weekly-hours/
+git commit -m "feat: clipboard copy/paste on the Weekly Hours editor"
+```
+
+---
+
+### Task 6: Holidays
+
+The only object-valued editor: `{ defaultHours, holidays }`. `sanitizeSchedule` in `holidays/holiday.ts` already takes `unknown` and returns a well-formed schedule, so this translator is the thinnest of the four.
+
+It deliberately does **not** drop expired holidays. `removeExpiredHolidays` affects the converted value and the Delivery API, not the editor — precisely so a mistyped date can still be corrected — and a paste that filtered them would contradict that.
+
+**Files:**
+- Create: `src/holidays/clipboard/paste.translator.ts`
+- Test: `src/holidays/clipboard/paste.translator.test.ts`
+- Modify: `src/holidays/manifest.ts`
+
+**Interfaces:**
+- Consumes: `unwrapEntryValue`, `OocClipboardEntryValue`, `OOC_HOLIDAYS_CLIPBOARD_ENTRY_VALUE_TYPE` (Task 1); `createTestHost` (Task 2); `oocClipboardManifests` (Task 3); `sanitizeSchedule` and `HolidaySchedule` from `src/holidays/holiday.ts` (both already exported).
+- Produces: `class OocHolidaysClipboardPasteTranslator` with `translate(entryValue: OocClipboardEntryValue<unknown>): Promise<HolidaySchedule>`, also exported as `api`.
+
+- [ ] **Step 1: Write the failing test**
+
+`src/holidays/clipboard/paste.translator.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { createTestHost } from '../../clipboard/test-host.js';
+import { wrapEntryValue } from '../../clipboard/entry-value.js';
+import { OocHolidaysClipboardPasteTranslator } from './paste.translator.js';
+import type { Holiday } from '../holiday.js';
+
+const translator = () => new OocHolidaysClipboardPasteTranslator(createTestHost());
+
+const holiday = (name: string, start: string, end: string): Holiday => ({
+    name,
+    start,
+    end,
+    repeatYearly: false,
+    hoursMode: 'closed',
+    hours: [],
+});
+
+describe('OocHolidaysClipboardPasteTranslator', () => {
+    it('returns the schedule the entry carries', async () => {
+        const schedule = {
+            defaultHours: [],
+            holidays: [holiday('Christmas Day', '2026-12-25', '2026-12-25')],
+        };
+
+        await expect(translator().translate(wrapEntryValue(schedule))).resolves.toEqual(schedule);
+    });
+
+    it('keeps an expired holiday - removeExpiredHolidays is a converter setting, not an editor one', async () => {
+        const schedule = {
+            defaultHours: [],
+            holidays: [holiday('Old Bank Holiday', '2020-01-01', '2020-01-01')],
+        };
+
+        const pasted = await translator().translate(wrapEntryValue(schedule));
+
+        expect(pasted.holidays).toHaveLength(1);
+    });
+
+    it('fills in a schedule missing its keys', async () => {
+        await expect(translator().translate(wrapEntryValue({}))).resolves.toEqual({
+            defaultHours: [],
+            holidays: [],
+        });
+    });
+
+    it('drops a holiday with an impossible date', async () => {
+        const schedule = {
+            defaultHours: [],
+            holidays: [holiday('Not A Day', '2026-02-30', '2026-02-30')],
+        };
+
+        const pasted = await translator().translate(wrapEntryValue(schedule));
+
+        expect(pasted.holidays).toEqual([]);
+    });
+
+    it('clones, so editing the pasted schedule does not reach the entry', async () => {
+        const entry = wrapEntryValue({
+            defaultHours: [],
+            holidays: [holiday('Christmas Day', '2026-12-25', '2026-12-25')],
+        });
+
+        const pasted = await translator().translate(entry);
+        pasted.holidays[0].name = 'changed';
+
+        expect(entry.value.holidays[0].name).toBe('Christmas Day');
+    });
+
+    it('rejects an unrecognised version', async () => {
+        await expect(translator().translate({ version: 99, value: {} })).rejects.toThrow();
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/holidays/clipboard/paste.translator.test.ts`
+Expected: FAIL — `Failed to resolve import "./paste.translator.js"`.
+
+- [ ] **Step 3: Write the implementation**
+
+`src/holidays/clipboard/paste.translator.ts`:
+
+```ts
+import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
+import type { UmbClipboardPastePropertyValueTranslator } from '@umbraco-cms/backoffice/clipboard';
+import { unwrapEntryValue, type OocClipboardEntryValue } from '../../clipboard/entry-value.js';
+import { sanitizeSchedule, type HolidaySchedule } from '../holiday.js';
+
+/**
+ * The one object-valued editor. `sanitizeSchedule` already takes `unknown` and returns a well-formed
+ * schedule, which is exactly the contract wanted here - a clipboard entry may have been written by
+ * an older build of the package.
+ *
+ * Expired holidays are deliberately kept: `removeExpiredHolidays` governs the converted value and
+ * the Delivery API, not the editor, so that a mistyped date can still be corrected.
+ */
+export class OocHolidaysClipboardPasteTranslator
+    extends UmbControllerBase
+    implements UmbClipboardPastePropertyValueTranslator<OocClipboardEntryValue<unknown>, HolidaySchedule>
+{
+    async translate(entryValue: OocClipboardEntryValue<unknown>): Promise<HolidaySchedule> {
+        return sanitizeSchedule(unwrapEntryValue<unknown>(entryValue));
+    }
+}
+
+export { OocHolidaysClipboardPasteTranslator as api };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/holidays/clipboard/paste.translator.test.ts`
+Expected: PASS — 6 tests.
+
+- [ ] **Step 5: Wire the manifests**
+
+In `src/holidays/manifest.ts`, add the two imports and spread the factory output after the existing `propertyEditorUi` manifest:
+
+```ts
+import { oocClipboardManifests } from '../clipboard/manifest-factory.js';
+import { OOC_HOLIDAYS_CLIPBOARD_ENTRY_VALUE_TYPE } from '../clipboard/constants.js';
+
+// ... existing propertyEditorUi manifest ...
+        ...oocClipboardManifests({
+            editorName: 'Holidays',
+            aliasSegment: 'Holidays',
+            propertyEditorUiAlias: 'OpenOrClosed.PropertyEditorUi.Holidays',
+            entryValueType: OOC_HOLIDAYS_CLIPBOARD_ENTRY_VALUE_TYPE,
+            pasteTranslatorApi: () => import('./clipboard/paste.translator.js'),
+        }),
+```
+
+- [ ] **Step 6: Build and run the whole suite**
+
+Run: `npm run build && npm test`
+Expected: `tsc` silent, vite build writes to `../wwwroot/App_Plugins/OpenOrClosed`, all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/holidays/
+git commit -m "feat: clipboard copy/paste on the Holidays editor"
+```
+
+---
+
+### Task 7: Manual checklist, README and changelog
+
+Unit tests cannot reach the part that matters most: whether a pasted value loads clean, or leaves the document *dirty* so the backoffice offers "Discard unsaved changes" on navigate-away. This checklist is written from the spec rather than from this plan, deliberately — a checklist derived from a plan cannot catch what the plan omitted.
+
+**Files:**
+- Create: `docs/superpowers/plans/2026-08-26-clipboard-copy-paste-checklist.md` (repository root, not `Client/`)
+- Modify: `README.md` (repository root) — feature note and changelog line
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: nothing further depends on this task.
+
+- [ ] **Step 1: Write the manual checklist**
+
+Create `docs/superpowers/plans/2026-08-26-clipboard-copy-paste-checklist.md` with a heading, a note that it is run against a real backoffice with at least two content nodes sharing the same document type, and these items as unchecked boxes:
+
+1. Copy on node A, paste on node B — for each of Standard Business Hours, Special Business Hours, Weekly Hours and Holidays.
+2. Paste into an empty property — no confirm dialog appears, the value lands.
+3. Paste into a property that already has a value — the confirm dialog names the clipboard entry; cancelling changes nothing.
+4. The Copy action is absent on an empty property (the `HasValue` condition), and the Paste action is absent on a read-only property (the `Writable` condition).
+5. Standard Hours copied from a data type with bank holidays, pasted into one without — 8 rows become 7, with no orphan row.
+6. The reverse — 7 rows become 8, with a correctly labelled bank-holiday row.
+7. A Special Hours entry containing only past dates, pasted into an editor with `removeOldDates` on — the entry does not appear in the picker at all.
+8. A Special Hours entry with mixed past and future dates — past ones are dropped after paste, future ones survive.
+9. A culture-variant property: copy on one culture, paste on another.
+10. Save and reload after **every** paste above; then publish and confirm the front-end value converter output is unchanged in shape. A pasted value that loads dirty, or that the converter reads differently from a hand-entered one, is the failure this whole checklist exists to catch.
+11. Clipboard entry names read `<Node name> - <Property label>`.
+12. Weekly Hours copied from a node, pasted into a node whose editor has a different `time_24hr` setting — times render in the target's format, values unchanged.
+
+- [ ] **Step 2: Add the README feature note and changelog line**
+
+In `README.md`, add clipboard copy/paste to the feature description for the property editors, and add a changelog line recording that all four editors now support Umbraco's property clipboard, with copy and replace-paste. Note explicitly that the clipboard is per-browser `localStorage` and that pasting is one node at a time — there is no bulk apply — so the README does not promise what issue #77 assumed.
+
+- [ ] **Step 3: Run the checklist**
+
+Work through every item against a real backoffice. Tick each box. If an item fails, stop and fix it before continuing — do not tick and carry on.
+
+- [ ] **Step 4: Record the result**
+
+Add a line at the top of the checklist stating the date it was run and whether it came back clean, matching how `2026-08-20-timeline-hours-editor-phase-2-checklist.md` records its passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/superpowers/plans/2026-08-26-clipboard-copy-paste-checklist.md README.md
+git commit -m "docs: manual checklist and README note for clipboard copy/paste"
+```
+
+---
+
+## Self-review notes
+
+Checked against the spec:
+
+- **Spec coverage** — every spec section maps to a task. The five manifests → Task 3's factory. The wrapper and version → Task 1. One shared copy translator → Task 2. The four paste translators, including the Special Hours `isCompatibleValue` and the two reused sanitisers → Tasks 3–6. Testing section → the test steps in Tasks 1–6 plus Task 7's checklist. README/changelog → Task 7. The spec's *Deferred: merge/append* section is deliberately unimplemented; nothing in this plan touches it.
+- **Type consistency** — `OocClipboardEntryValue<T>`, `wrapEntryValue`, `unwrapEntryValue`, `createTestHost`, `oocClipboardManifests` and `OocClipboardManifestArgs` are used with the same names and signatures in every task that consumes them. The four `api` exports each live in their own module, which is what the extension loader requires.
+- **Verified against the real packages** — every import path in this plan (`class-api`, `controller-api`, `clipboard`, `property`), both condition alias constants, the `implements` clauses against `UmbControllerBase`, and all five manifest shapes were compiled with `tsc --noEmit` before this plan was written. `UmbControllerBase` was also confirmed to construct under vitest's node environment with the `createTestHost` stub, which is what makes the translators directly unit-testable.
+- **Known gap** — the manifest factory has no unit test of its own. It emits static objects with no branching, and Task 3 Step 8's `tsc --noEmit` typechecks every field against the backoffice's manifest union, which is the check that would actually catch a mistake. Its real verification is checklist items 1–4.

--- a/docs/superpowers/specs/2026-08-26-clipboard-copy-paste-design.md
+++ b/docs/superpowers/specs/2026-08-26-clipboard-copy-paste-design.md
@@ -1,0 +1,196 @@
+# Clipboard copy/paste for the property editors — design
+
+## Context
+
+[Issue #77](https://github.com/umbraco-community/OpenOrClosed/issues/77) asks for Umbraco's clipboard support on the Standard and Special Business Hours editors. The reporter manages opening hours for a large number of branch locations, each a separate content node. Standard weekly hours are set once per branch; special hours — bank holidays, Christmas closures, one-off events — need applying identically across most or all branches at the same time, and today that is done by hand, node by node.
+
+Umbraco 17.1 ships a full property-value clipboard in `@umbraco-cms/backoffice/clipboard`: two `propertyAction` kinds, a `propertyContext` kind, and a pair of per-editor value translators. Nothing in it is editor-specific — a property editor opts in by registering five manifests. The Block List's registration (`packages/block/block-list/clipboard/manifests.js` in the backoffice package) is the reference implementation this design follows.
+
+Both target editors are already `ValueTypes.Json` with a `propertyEditorSchemaAlias` set, which is everything the clipboard requires. **This change touches no C# and adds no localisation keys.**
+
+### The issue's premise needs one correction
+
+The issue treats "copy/paste" and Umbraco's "Copy to other nodes" as one mechanism. They are not, and the difference is material to what #77 can deliver:
+
+- **The clipboard is real.** Copy on branch A, open branch B, paste. Entries are named `<Node name> - <Property label>` by the core copy action, so "Manchester - Special Business Hours" stays findable later.
+- **There is no core bulk "apply this property value to N selected nodes."** The only document entity bulk actions in 17.1 are publish, unpublish, move-to, duplicate-to and trash. None writes a single property across a selection.
+- **The clipboard is browser `localStorage`** (`clipboard-local-storage.manager.js`), per browser and per user. It is not a server-side clipboard shared between editors.
+
+So the outcome for the reporter is: copy once, then one paste per branch. For a hundred branches that is a hundred pastes — a large improvement on typing a hundred dates, but not "a few clicks". A genuine bulk apply needs a server-side endpoint writing property values across documents, with permissions, variants, publish state and validation to answer for. That is a separate feature, not this one, and the issue should be answered plainly rather than left to imply it is covered.
+
+## Scope
+
+**In scope**
+
+- Clipboard copy and paste (replace) on all four property editors: Standard Business Hours, Special Business Hours, Weekly Hours, Holidays.
+- One clipboard entry value type per editor, versioned.
+- One shared copy translator; four paste translators.
+- Unit tests for every translator, and a manual backoffice checklist written from this spec.
+- README feature note and changelog line.
+
+**Out of scope**
+
+- **Merge/append paste** for Special Business Hours. Deferred to a follow-up issue; decisions already settled for it are recorded under *Deferred: merge/append* so the follow-up does not have to re-litigate them.
+- **Bulk paste across selected nodes.** Not possible with core extension points; see above.
+- **Cross-editor pasting**, in particular Standard Hours ↔ Weekly Hours. Both are weekly, but the shapes are unrelated and a translator pair would re-implement the mapping in `Migrations/Upgrade/MigrateOpenOrClosedDataTypes.cs`.
+- Any C# change. None is needed.
+- The hardcoded English labels still in `standard-hours/manifest.ts` and `special-hours/manifest.ts`. Pre-existing drift from the localisation phase; unrelated to the clipboard and left alone.
+
+## Settled decisions
+
+| Decision | Choice | Why |
+|---|---|---|
+| Editors covered | All four | The factory makes each extra editor ~15 lines of manifest plus one paste translator. Weekly Hours has the same per-branch duplication problem, and a right-click action present on two editors but missing on the other two reads as a bug. |
+| Paste semantics in this change | Replace only | Matches every clipboard-enabled core editor. Independently shippable and closes #77. |
+| Entry value types | One per editor | Prevents a weekly value ever reaching a date-keyed editor. The type string is the compatibility contract; nothing else has to check. |
+| Wire format | `{ version: 1, value: <property value> }` | Entries sit in `localStorage` indefinitely. The version lets a future shape change decline stale entries instead of writing a broken value. One generic wrapper covers both the array-valued editors and the object-valued Holidays. |
+| Copy translator count | One, registered four times | It never needs to know the type — the manifest's `toClipboardEntryValueType` supplies it. The body is a clone and a wrap. |
+| Paste normalisation | Per editor, reusing existing sanitisers | `translate()` receives **no config** (see below), so anything config-dependent must stay where it already is: in the elements. |
+| New localisation keys | None | The `copyToClipboard` and `pasteFromClipboard` kinds carry their own icons and labels ("Copy", "Replace") from core. Deferring merge removed the only strings this change would have added. |
+| Manifest location | Beside the editor each set belongs to | `bundle.manifests.ts` needs no change; the manifests ride along with the editor's own `manifest.ts`. |
+
+## The constraint that shapes the paste side
+
+`UmbClipboardPastePropertyValueTranslator.translate(clipboardEntryValue)` receives the clipboard value and nothing else. Only the optional `isCompatibleValue(propertyValue, config)` sees the property editor's configuration.
+
+A paste translator therefore **cannot** normalise against `showBankHolidays`, `removeOldDates`, `excludeTimes` or any other setting. This is not a problem, because both legacy editors already self-heal on any incoming value: `_initializeValue` runs from `willUpdate` whenever `value` changes, so Standard Hours slices 8→7 or extends 7→8 and re-labels the bank-holiday row from config, and Special Hours re-runs `_removeOldDates`. The translators stay near-identity and the elements keep sole responsibility for config-dependent shape.
+
+`isCompatibleValue` is used for one thing only, where it earns its place: hiding a Special Hours entry from the picker when every date in it is already past and `removeOldDates` is on. Without the guard the paste succeeds, the element immediately filters everything out, and the editor sees nothing happen.
+
+## Architecture
+
+### Manifests, per editor
+
+Five manifests, the same five the Block List registers:
+
+| Manifest | Detail |
+|---|---|
+| `propertyContext`, kind `clipboard` | `forPropertyEditorUis: [<ui alias>]`. Supplies `UMB_CLIPBOARD_PROPERTY_CONTEXT` to the actions. |
+| `propertyAction`, kind `copyToClipboard` | Condition `UMB_PROPERTY_HAS_VALUE_CONDITION_ALIAS` (`Umb.Condition.Property.HasValue`). |
+| `propertyAction`, kind `pasteFromClipboard` | Condition `UMB_WRITABLE_PROPERTY_CONDITION_ALIAS` (`Umb.Condition.Property.Writable`). Core confirms before overwriting a non-empty property. |
+| `clipboardCopyPropertyValueTranslator` | `fromPropertyEditorUi` → `toClipboardEntryValueType`. |
+| `clipboardPastePropertyValueTranslator` | `fromClipboardEntryValueType` → `toPropertyEditorUi`. |
+
+A copy translator is **not** optional. `UmbClipboardCopyPropertyValueTranslatorValueResolver.resolve` throws `No clipboard copy translators found.` when no manifest matches the editor, so registering the actions without one gives an action that only errors.
+
+All four registrations are structurally identical, so a factory emits the set from `(uiAlias, entryValueType, pasteTranslatorImport)` — the same sharing instinct as `shared/business-hours-base.element.ts`. Manifest interfaces are declared into the global `UmbExtensionManifestMap` by the backoffice package, so the existing `Array<UmbExtensionManifest>` annotation types them with no imports.
+
+No `propertyValueCloner` is needed: `UmbPropertyValueCloneController` returns the value untouched when no cloner matches the editor alias, and these values are plain JSON.
+
+### Files
+
+```
+Client/src/clipboard/
+  constants.ts                     the four entry value types
+  manifest-factory.ts              the five manifests for one editor
+  hours-copy.translator.ts         shared by all four editors
+  hours-copy.translator.test.ts
+  entry-value.ts                   the versioned wrapper: type, wrap, unwrap
+  entry-value.test.ts
+Client/src/standard-hours/clipboard/paste.translator.ts   (+ .test.ts)
+Client/src/special-hours/clipboard/paste.translator.ts    (+ .test.ts)
+Client/src/weekly-hours/clipboard/paste.translator.ts     (+ .test.ts)
+Client/src/holidays/clipboard/paste.translator.ts         (+ .test.ts)
+```
+
+Each editor's existing `manifest.ts` spreads its factory output alongside the `propertyEditorUi` manifest it already exports.
+
+### Entry value types
+
+```ts
+export const OOC_STANDARD_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE = 'openOrClosed.standardHours';
+export const OOC_SPECIAL_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE  = 'openOrClosed.specialHours';
+export const OOC_WEEKLY_HOURS_CLIPBOARD_ENTRY_VALUE_TYPE   = 'openOrClosed.weeklyHours';
+export const OOC_HOLIDAYS_CLIPBOARD_ENTRY_VALUE_TYPE       = 'openOrClosed.holidays';
+```
+
+### The wrapper
+
+```ts
+export const OOC_CLIPBOARD_ENTRY_VERSION = 1;
+
+export interface OocClipboardEntryValue<T> {
+    version: number;
+    value: T;
+}
+```
+
+`wrap(value)` clones and stamps. `unwrap(entryValue)` returns the inner value, or throws when the argument is not an object, when `version` is missing, or when `version` is anything other than a version this build understands. Throwing is right: the paste action surfaces the failure rather than silently writing rubbish into a document.
+
+### Copy translator
+
+One class for every editor. `translate(propertyValue)` returns `wrap(propertyValue)`. It must `structuredClone` — the property value it is handed is live editor state, and the entry is about to be serialised into `localStorage`.
+
+### Paste translators
+
+| Editor | `translate` | `isCompatibleValue` |
+|---|---|---|
+| Standard Hours | `unwrap`, clone | none |
+| Special Hours | `unwrap`, clone | see below |
+| Weekly Hours | `unwrap`, then per day: drop the day unless `day` is an integer 0–6, then `sanitizeRanges(day.ranges)`, then drop the day if no ranges survive | none |
+| Holidays | `unwrap`, then `sanitizeSchedule(value)` | none |
+
+Standard Hours needs no array check of its own: the element already rebuilds a default week when `value` is not an array, so a malformed entry degrades to a fresh week rather than a broken one.
+
+Special Hours `isCompatibleValue` returns **false** when `removeOldDates` is on and the value contains no entry whose date is today or later. That covers both the all-past entry and the empty entry — in each case the paste would visibly do nothing. With `removeOldDates` off it always returns true.
+
+`sanitizeRanges` (`timeline/time-range.ts`) and `sanitizeSchedule` (`holidays/holiday.ts`) already exist, are DOM-free and are already unit-tested. Both accept `unknown` and coerce, which is exactly the contract wanted at a trust boundary — a clipboard entry may have been written by an older build of the package.
+
+Holidays deliberately does **not** filter expired holidays on paste. `removeExpiredHolidays` affects the converted value and the Delivery API, not the editor, precisely so a mistyped date can still be corrected; a paste that dropped them would contradict that.
+
+## Testing
+
+All translators are DOM-free, so vitest covers them directly, matching the `time-range.test.ts` convention.
+
+- **Round trip** — copy then paste returns a value deep-equal to the original, for each of the four editors.
+- **Version rejection** — `unwrap` throws on `version: 0`, `version: 2`, a missing `version`, `null`, and a bare unwrapped array.
+- **Clone isolation** — mutating the value handed to the copy translator does not change the entry; mutating a pasted value does not change the entry it came from.
+- **Weekly Hours sanitisation** — a day with no valid ranges is dropped; malformed ranges are coerced by `sanitizeRanges`.
+- **Holidays sanitisation** — a schedule missing `defaultHours` or `holidays` comes back well-formed.
+- **Special Hours compatibility** — all-past entry and empty entry rejected when `removeOldDates` is on, both accepted when off; a mixed past/future entry accepted either way. Dates are compared as calendar dates against the browser's own today, not UTC — the bug `_removeOldDates` already carries a comment about.
+
+A manual checklist under `docs/superpowers/plans/`, written **from this spec** rather than from its plan, covering what unit tests cannot reach:
+
+1. Copy on node A, paste on node B, for each of the four editors.
+2. Paste into an empty property — no confirm dialog, value lands.
+3. Paste into a property that already has a value — confirm dialog names the entry, cancelling changes nothing.
+4. Copy action absent on an empty property (the `HasValue` condition); paste action absent on a read-only property (the `Writable` condition).
+5. Standard Hours copied from a data type with bank holidays, pasted into one without — 8 rows become 7, no orphan row.
+6. The reverse — 7 rows become 8 with a correctly labelled bank-holiday row.
+7. Special Hours entry containing only past dates, pasted into an editor with `removeOldDates` on — the entry does not appear in the picker at all.
+8. Special Hours entry with mixed dates — past ones are dropped after paste, future ones survive.
+9. A culture-variant property: copy on one culture, paste on another.
+10. Save and reload after every paste; then publish and confirm the front-end value converter output is unchanged in shape.
+11. Clipboard entry names read `<Node name> - <Property label>`.
+
+Item 10 matters more than it looks: a pasted value that loads dirty, or that the converter reads differently from a hand-entered one, is the failure mode worth catching before release.
+
+## Delivery order
+
+1. `entry-value.ts` + tests. Nothing else can be written honestly until the wrapper's failure behaviour is settled.
+2. `hours-copy.translator.ts` + tests, and `constants.ts`.
+3. `manifest-factory.ts`.
+4. Standard Hours: paste translator, tests, manifest wiring. First editor through end to end — verify in the backoffice before repeating.
+5. Special Hours, including `isCompatibleValue` and its tests.
+6. Weekly Hours.
+7. Holidays.
+8. Manual checklist run; README feature note and changelog line.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| A pasted value loads *dirty*, so the document shows "Discard unsaved changes" on navigate-away | The elements normalise incoming values in `_initializeValue`, which is exactly what would otherwise happen on load and mark the document dirty. Manual checklist item 10 is the check that this holds. |
+| Stale `localStorage` entries after a future value-shape change | The `version` stamp, and `unwrap` throwing rather than coercing. |
+| `translate()` being config-blind is discovered late to be insufficient | Both legacy elements already self-heal, verified by reading `_initializeValue` and `willUpdate`. Checklist items 5–8 exercise the config mismatches directly. |
+| The reporter expects bulk apply and #77 does not deliver it | Answered explicitly on the issue when the work lands, with the follow-up issue for merge/append linked. |
+
+## Deferred: merge/append
+
+For the follow-up issue, so it does not start from scratch. Not built here.
+
+A merge action for Special Business Hours is our own `propertyAction` — not a core kind — with a weight just under the core paste's 1190 so it sits below "Replace" in the menu. Its api consumes `UMB_PROPERTY_CONTEXT` and `UMB_CLIPBOARD_PROPERTY_CONTEXT`, calls `pick({ propertyEditorUiAlias, multiple: false })`, merges, and calls `setValue`. Condition: `UMB_WRITABLE_PROPERTY_CONDITION_ALIAS`. It needs the one localisation key this change avoided.
+
+Settled merge rule: **dedupe by calendar date, incoming wins, result sorted ascending.** Incoming-wins matches "head office decides all branches close on this day". Keeping both entries was rejected — two entries for one date is ambiguous to the value converter and the Delivery API, with no UI to disambiguate. Date comparison reuses the element's existing `_dateKey` normalisation so a stored `2026-12-25T00:00:00` and a copied `2026-12-25` count as the same day; that logic should move to a pure, tested `mergeSpecialDays(existing, incoming)` module rather than living in the action.
+
+Merge is meaningless for Standard Hours and Weekly Hours (fixed or day-keyed weeks) and for Holidays' `defaultHours`, so it is Special Hours only.

--- a/docs/superpowers/specs/2026-08-26-clipboard-copy-paste-design.md
+++ b/docs/superpowers/specs/2026-08-26-clipboard-copy-paste-design.md
@@ -83,6 +83,7 @@ No `propertyValueCloner` is needed: `UmbPropertyValueCloneController` returns th
 Client/src/clipboard/
   constants.ts                     the four entry value types
   manifest-factory.ts              the five manifests for one editor
+  manifest.ts                      all four editors' registrations
   hours-copy.translator.ts         shared by all four editors
   hours-copy.translator.test.ts
   entry-value.ts                   the versioned wrapper: type, wrap, unwrap
@@ -93,7 +94,11 @@ Client/src/weekly-hours/clipboard/paste.translator.ts     (+ .test.ts)
 Client/src/holidays/clipboard/paste.translator.ts         (+ .test.ts)
 ```
 
-Each editor's existing `manifest.ts` spreads its factory output alongside the `propertyEditorUi` manifest it already exports.
+All four registrations live in `src/clipboard/manifest.ts`, spread into `bundle.manifests.ts` last, after every property editor UI they reference.
+
+> **Amended during implementation.** This originally had each editor's own `manifest.ts` spread its factory output, on the grounds that `bundle.manifests.ts` would then need no change. That does not work. The factory imports Umbraco's condition aliases at *runtime*, and `@umbraco-cms/backoffice/property` touches `document` while it loads — so any node test importing an editor's manifest module dies, and `localization/en.test.ts` imports two of them. Inlining the dependency for vitest only got as far as the DOM access, so the constraint is real rather than a config wrinkle: **an editor's `manifest.ts` cannot carry a runtime backoffice import.** Centralising fixes it, because nothing imports `src/clipboard/manifest.ts` but the bundle.
+>
+> The alternative — hardcoding the two alias strings, as these manifest files already do for `Umb.PropertyEditorUi.Toggle` — was rejected on a verified difference: a misspelled imported constant is a compile error, while a misspelled string literal is not. The `conditions[].alias` field does not constrain the string, so a typo there would silently hide the action instead of failing the build.
 
 ### Entry value types
 


### PR DESCRIPTION
Addresses #77. **Not auto-closing it** — the issue asks for a bulk apply that core does not provide, so the close decision is yours. See *Scope* below.

## What this adds

All four property editors — Standard Business Hours, Special Business Hours, Weekly Hours and Holidays — now opt into Umbraco's property clipboard. **Copy** an editor's value from the property action menu on one node, **Replace** it on the same property on another node.

Registration is the same five manifests core's Block List uses, emitted per editor by a factory:

| Manifest | Notes |
|---|---|
| `propertyContext` kind `clipboard` | supplies `UMB_CLIPBOARD_PROPERTY_CONTEXT` |
| `propertyAction` kind `copyToClipboard` | gated on `Umb.Condition.Property.HasValue` |
| `propertyAction` kind `pasteFromClipboard` | gated on `Umb.Condition.Property.Writable`; core confirms before overwriting |
| `clipboardCopyPropertyValueTranslator` | one shared translator serves all four editors |
| `clipboardPastePropertyValueTranslator` | one per editor, since each sanitises its own shape |

Clipboard values are versioned (`{ version: 1, value: … }`). Entries live in `localStorage` indefinitely, so an unrecognised version is declined rather than guessed at — a wrong guess would write rubbish into a document.

Each editor has its own entry value type, so a Weekly Hours value can never be pasted into Special Business Hours. Cross-editor translation was deliberately left out; between Standard and Weekly it would re-implement the mapping in `MigrateOpenOrClosedDataTypes.cs`.

**No C# changes, and no new localisation keys** — the copy/paste kinds carry their own icons and labels from core.

## Scope — please read before closing #77

The issue treats the clipboard and "Copy to other nodes" as one mechanism. They aren't:

- **Core has no bulk "apply this property to the selected nodes" action.** The only document entity bulk actions in 17.1 are publish, unpublish, move-to, duplicate-to and trash. None writes a single property across a selection.
- **The clipboard is browser `localStorage`** — per browser, per user, not shared between editors.

So this delivers copy once, then one paste per node. For a hundred branches that's a hundred pastes — far better than typing a hundred dates, but not the "few clicks" the issue envisaged. A real bulk apply needs a server-side endpoint writing property values across documents, with permissions, variants, publish state and validation to answer for. The README now says this plainly so it isn't over-promised.

Also agreed as out of scope: **merge/append** paste for Special Business Hours (the "branch keeps its own dates and gains the shared closures" case). Deferred to a follow-up, with its decisions already settled in the spec — incoming wins, dedupe by calendar date, sorted ascending.

## Verification

- `tsc --noEmit` clean, `npm run build` clean.
- **181 tests pass** (129 pre-existing + 52 new), covering version rejection, clone isolation, per-editor sanitisation, and the Special Hours compatibility guard.
- Bundle inspected: all four registrations ship, the factory ships once, and both condition aliases arrive as an external import rather than inlined strings.
- ⚠️ The 13-item manual checklist (`docs/superpowers/plans/2026-08-26-clipboard-copy-paste-checklist.md`) is committed but **not ticked off**. Item 10 — that a pasted value loads clean rather than leaving the document dirty — is the one worth doing before release.

## Two design notes worth reviewing

1. **Paste translators can't see config.** `translate()` receives only the clipboard value; just `isCompatibleValue()` gets config. That's fine because both legacy editors already self-heal in `_initializeValue` — Standard Hours trims 8 rows to 7 from `showBankHolidays`, Special Hours re-runs `_removeOldDates`. `isCompatibleValue` is used for exactly one thing: hiding an all-past Special Hours entry when `removeOldDates` is on, which would otherwise paste and visibly do nothing.

2. **Clipboard manifests are centralised in `src/clipboard/manifest.ts`, not wired per editor.** The factory imports Umbraco's condition aliases at runtime, and `@umbraco-cms/backoffice/property` touches `document` while loading — so wiring it into an editor's `manifest.ts` breaks `localization/en.test.ts`, which imports two of those modules in vitest's node environment. Inlining the deps for vitest only got as far as the DOM access. Hardcoding the alias strings was rejected: a misspelled imported constant is a compile error, a misspelled literal is not.

Design and plan are committed under `docs/superpowers/` for review alongside the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)