### PR TITLE
release: 17.3.0

### DIFF
--- a/OpenOrClosed/OpenOrClosed.csproj
+++ b/OpenOrClosed/OpenOrClosed.csproj
@@ -11,7 +11,7 @@
 
 	<!-- NuGet package metadata -->
 	<PropertyGroup>
-		<Version>17.2.0</Version>
+		<Version>17.3.0</Version>
 		<Description>
 			Open or Closed - Yet another Business Hours package!
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,13 @@ A few behaviours worth knowing:
 
 ## Change Log
 
+### Version 17.3.0
+
+* All four property editors now support Umbraco's property clipboard: **Copy** an editor's value
+  from one node and **Replace** it on another. Note that the clipboard is per browser, and that
+  pasting is one node at a time — Umbraco has no bulk apply. See
+  [Copying hours between nodes](#copying-hours-between-nodes).
+
 ### Version 17.2.0
 
 * Added **Weekly Hours** — a recurring Monday-to-Sunday schedule drawn on seven timelines, with
@@ -196,10 +203,6 @@ A few behaviours worth knowing:
   range is added or deleted, and block tooltips appear on keyboard focus as well as hover.
 * All four property editors now dispatch `UmbChangeEvent` rather than the deprecated
   `property-value-change`, which Umbraco removes in 20.0.0.
-* All four property editors now support Umbraco's property clipboard: **Copy** an editor's value
-  from one node and **Replace** it on another. Note that the clipboard is per browser, and that
-  pasting is one node at a time — Umbraco has no bulk apply. See
-  [Copying hours between nodes](#copying-hours-between-nodes).
 
 ### Version 17.1.2
 


### PR DESCRIPTION
Releases the clipboard copy/paste work merged in #85.

## What's in it

| Change | |
|---|---|
| `OpenOrClosed.csproj` | `<Version>` 17.2.0 → **17.3.0** |
| `README.md` | clipboard changelog entry moved into a new 17.3.0 section |

`release.yml` reads `<Version>` straight from the csproj, so this bump is what actually makes a merge publish.

## Why the changelog change is here and not in #85

The entry was originally written under `### Version 17.2.0`, which shipped on 20 August. I pushed a fix moving it to 17.3.0, but #85 had already been merged by then, so it never landed. Merging this corrects it — until then the README claims clipboard support shipped in 17.2.0, which it didn't.

## Heads-up on the failed release run

Merging #85 fired `release.yml` while the csproj still read 17.2.0. That run [failed](https://github.com/umbraco-community/OpenOrClosed/actions/runs/33022871573) at *Create Release Tag v17.2.0*:

```
Validation Failed: {"resource":"Release","code":"already_exists","field":"tag_name"},
{"resource":"Release","code":"custom","field":"tag_name",
 "message":"tag_name was used by an immutable release"}
```

**Nothing was wrongly published.** The NuGet step ran before the tag step and was a no-op thanks to `--skip-duplicate`, so 17.2.0 on NuGet is still the 20 August build. The red run is cosmetic and this PR is the fix — on merge, `release.yml` will publish `17.3.0` and tag `v17.3.0` cleanly.

Worth noting for future releases: because `release.yml` triggers on *every* push to master, a feature PR that merges without a version bump will always produce one of these failed runs. Bundling the bump into the feature PR avoids it.

## Verification

Everything the release workflow will run, run locally on this branch:

- `npm run build` — clean
- `npm test` — **181 passed**
- `dotnet build --configuration Release` — 0 errors
- `dotnet test --configuration Release` — **149 passed**
- `dotnet pack` — produces `OpenOrClosed.17.3.0.nupkg`, and I confirmed the clipboard code is present in the packaged `staticwebassets/App_Plugins/OpenOrClosed/open-or-closed.js`

## Still outstanding

- The 13-item manual checklist (`docs/superpowers/plans/2026-08-26-clipboard-copy-paste-checklist.md`) is committed but unticked. You confirmed the feature working before merging #85; the checklist items worth a look before this goes public are the config-mismatch ones (5–8) and item 10, that a pasted value loads clean rather than leaving the document dirty.
- The merge/append paste for Special Business Hours is still deferred, with its decisions recorded in the spec.

Two version fields elsewhere are stale and deliberately untouched, since neither feeds the release: `Client/package.json` (`17.0.0`, private) and `Client/public/umbraco-package.json` (`4.0.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)